### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/193/019/421193019.geojson
+++ b/data/421/193/019/421193019.geojson
@@ -266,6 +266,9 @@
     },
     "wof:country":"BI",
     "wof:created":1459009757,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"00278aeb974b86d64b51a10b7dc456ad",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
         }
     ],
     "wof:id":421193019,
-    "wof:lastmodified":1566614934,
+    "wof:lastmodified":1582345863,
     "wof:name":"Gitanga",
     "wof:parent_id":85668731,
     "wof:placetype":"county",

--- a/data/421/196/575/421196575.geojson
+++ b/data/421/196/575/421196575.geojson
@@ -223,6 +223,9 @@
     },
     "wof:country":"BI",
     "wof:created":1459009886,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"784cc94a482c36dc79d3e8c5cbfb0da7",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
         }
     ],
     "wof:id":421196575,
-    "wof:lastmodified":1566614936,
+    "wof:lastmodified":1582345863,
     "wof:name":"Rutana",
     "wof:parent_id":85668731,
     "wof:placetype":"county",

--- a/data/421/201/115/421201115.geojson
+++ b/data/421/201/115/421201115.geojson
@@ -118,6 +118,9 @@
     },
     "wof:country":"BI",
     "wof:created":1459010051,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62f495d59ec96b0deff4b34f7789ff43",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
         }
     ],
     "wof:id":421201115,
-    "wof:lastmodified":1566614937,
+    "wof:lastmodified":1582345863,
     "wof:name":"Ngozi",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/421/204/423/421204423.geojson
+++ b/data/421/204/423/421204423.geojson
@@ -86,6 +86,9 @@
     },
     "wof:country":"BI",
     "wof:created":1459010185,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd36e4f7dbfe823bdb982f300dc6af7f",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":421204423,
-    "wof:lastmodified":1566614935,
+    "wof:lastmodified":1582345863,
     "wof:name":"Mutimbuzi",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/421/204/487/421204487.geojson
+++ b/data/421/204/487/421204487.geojson
@@ -589,6 +589,9 @@
     },
     "wof:country":"BI",
     "wof:created":1459010187,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"12cfbcf85d3cb82d0835640b38f4bf43",
     "wof:hierarchy":[
         {
@@ -600,7 +603,7 @@
         }
     ],
     "wof:id":421204487,
-    "wof:lastmodified":1566614935,
+    "wof:lastmodified":1582345863,
     "wof:name":"Bujumbura",
     "wof:parent_id":1108759477,
     "wof:placetype":"locality",

--- a/data/856/322/85/85632285.geojson
+++ b/data/856/322/85/85632285.geojson
@@ -927,6 +927,11 @@
     },
     "wof:country":"BI",
     "wof:country_alpha3":"BDI",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"4bd9bbaa99d1ac96fecd027901d1de7e",
     "wof:hierarchy":[
         {
@@ -943,7 +948,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614520,
+    "wof:lastmodified":1582345856,
     "wof:name":"Burundi",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/687/25/85668725.geojson
+++ b/data/856/687/25/85668725.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Cankuzo Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4fdfb8b06795829256b724aa535d3799",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614520,
+    "wof:lastmodified":1582345856,
     "wof:name":"Cankuzo",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/27/85668727.geojson
+++ b/data/856/687/27/85668727.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Karuzi Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"277c67cad17f2afd8b29fb703c4e8c27",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614516,
+    "wof:lastmodified":1582345854,
     "wof:name":"Karuzi",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/31/85668731.geojson
+++ b/data/856/687/31/85668731.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Rutana Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"572980a89266745e30b750b5cf184a1b",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614517,
+    "wof:lastmodified":1582345855,
     "wof:name":"Rutana",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/35/85668735.geojson
+++ b/data/856/687/35/85668735.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Ruyigi Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"696c88cc18f76865cfe5b0e5a9e804b5",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614516,
+    "wof:lastmodified":1582345854,
     "wof:name":"Ruyigi",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/39/85668739.geojson
+++ b/data/856/687/39/85668739.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Bubanza Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a49b6ee4448f0625c7c091bc04810d1e",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614518,
+    "wof:lastmodified":1582345855,
     "wof:name":"Bubanza",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/45/85668745.geojson
+++ b/data/856/687/45/85668745.geojson
@@ -287,6 +287,9 @@
         "wk:page":"Bururi Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"33c7a800de647d6fe83a04ec34ea811f",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614516,
+    "wof:lastmodified":1582345855,
     "wof:name":"Bururi",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/49/85668749.geojson
+++ b/data/856/687/49/85668749.geojson
@@ -281,6 +281,9 @@
         "wk:page":"Cibitoke Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6212c20c5d2e446bde162e3ea6580ec",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614519,
+    "wof:lastmodified":1582345856,
     "wof:name":"Cibitoke",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/53/85668753.geojson
+++ b/data/856/687/53/85668753.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Gitega Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f419029fb4466a05c71d904167b69262",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614518,
+    "wof:lastmodified":1582345855,
     "wof:name":"Gitega",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/57/85668757.geojson
+++ b/data/856/687/57/85668757.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Kayanza Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1d4b823c90f0aac79f5ba9cb2c9d6bd6",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614516,
+    "wof:lastmodified":1582345854,
     "wof:name":"Kayanza",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/63/85668763.geojson
+++ b/data/856/687/63/85668763.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Makamba Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bae4245fe62fd12a271845edf7439be7",
     "wof:hierarchy":[
         {
@@ -302,7 +305,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614519,
+    "wof:lastmodified":1582345855,
     "wof:name":"Makamba",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/81/85668781.geojson
+++ b/data/856/687/81/85668781.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Ngozi Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d6d42e9dd22f2c0667b321d590be658f",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614517,
+    "wof:lastmodified":1582345855,
     "wof:name":"Ngozi",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/83/85668783.geojson
+++ b/data/856/687/83/85668783.geojson
@@ -290,6 +290,9 @@
         "wk:page":"Kirundo Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3e3b2d0effa7438d903facc0082118cf",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614519,
+    "wof:lastmodified":1582345856,
     "wof:name":"Kirundo",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/87/85668787.geojson
+++ b/data/856/687/87/85668787.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Muyinga Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f16033885f578ce6c4bb807e3c0e8b97",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614516,
+    "wof:lastmodified":1582345855,
     "wof:name":"Muyinga",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/91/85668791.geojson
+++ b/data/856/687/91/85668791.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Bujumbura Mairie Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d70a804d1f34366beb9f129c88aac63d",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614517,
+    "wof:lastmodified":1582345855,
     "wof:name":"Bujumbura Mairie",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/97/85668797.geojson
+++ b/data/856/687/97/85668797.geojson
@@ -280,6 +280,9 @@
         "wk:page":"Muramvya Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bbb2d88c87983efd49caa880d868d785",
     "wof:hierarchy":[
         {
@@ -297,7 +300,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614518,
+    "wof:lastmodified":1582345855,
     "wof:name":"Muramvya",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/99/85668799.geojson
+++ b/data/856/687/99/85668799.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Bujumbura Rural Province"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"421168bfffc64a7542744817da220e48",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614518,
+    "wof:lastmodified":1582345855,
     "wof:name":"Bujumbura Rural",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/688/01/85668801.geojson
+++ b/data/856/688/01/85668801.geojson
@@ -271,6 +271,9 @@
         "wd:id":"Q2458075"
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"34eef2578c1dec5f3ec8fbcf30ef885e",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1566614515,
+    "wof:lastmodified":1582345854,
     "wof:name":"Mwaro",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/857/718/25/85771825.geojson
+++ b/data/857/718/25/85771825.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":241138
     },
     "wof:country":"BI",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"61356b3982d76e2031b5453d3820feac",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566614515,
+    "wof:lastmodified":1582345854,
     "wof:name":"Ngagara",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.