### PR TITLE
Name updates

### DIFF
--- a/data/856/322/85/85632285.geojson
+++ b/data/856/322/85/85632285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.183108,
-    "geom:area_square_m":26946965846.802116,
+    "geom:area_square_m":26946966393.041061,
     "geom:bbox":"29.000993,-4.46918,30.850173,-2.309987",
     "geom:latitude":-3.365469,
     "geom:longitude":29.891759,
@@ -51,6 +51,9 @@
     "name:arg_x_preferred":[
         "Burundi"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u0648\u0631\u0648\u0646\u062f\u064a"
+    ],
     "name:arz_x_preferred":[
         "\u0628\u0648\u0631\u0648\u0646\u062f\u0649"
     ],
@@ -67,6 +70,9 @@
         "\u0411\u0443\u0440\u0443\u043d\u0434\u0438"
     ],
     "name:bam_x_preferred":[
+        "Burundi"
+    ],
+    "name:ban_x_preferred":[
         "Burundi"
     ],
     "name:bcl_x_preferred":[
@@ -147,6 +153,12 @@
     "name:dan_x_preferred":[
         "Burundi"
     ],
+    "name:deu_at_x_preferred":[
+        "Burundi"
+    ],
+    "name:deu_ch_x_preferred":[
+        "Burundi"
+    ],
     "name:deu_x_preferred":[
         "Burundi"
     ],
@@ -167,6 +179,12 @@
     ],
     "name:ell_x_preferred":[
         "\u039c\u03c0\u03bf\u03c5\u03c1\u03bf\u03cd\u03bd\u03c4\u03b9"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Burundi"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Burundi"
     ],
     "name:eng_x_preferred":[
         "Burundi"
@@ -232,6 +250,9 @@
         "Burunndi"
     ],
     "name:gag_x_preferred":[
+        "Burundi"
+    ],
+    "name:gcr_x_preferred":[
         "Burundi"
     ],
     "name:ger_x_variant":[
@@ -467,6 +488,9 @@
     "name:mon_x_preferred":[
         "\u0411\u0443\u0440\u0443\u043d\u0434\u0438"
     ],
+    "name:mri_x_preferred":[
+        "Puruniti"
+    ],
     "name:mrj_x_preferred":[
         "\u0411\u0443\u0440\u0443\u043d\u0434\u0438"
     ],
@@ -518,6 +542,9 @@
     "name:nov_x_preferred":[
         "Burundi"
     ],
+    "name:nqo_x_preferred":[
+        "\u07d3\u07ce\u07d9\u07ce\u07f2\u07d8\u07cc\u07eb"
+    ],
     "name:nso_x_preferred":[
         "Burundi"
     ],
@@ -561,6 +588,9 @@
         "\u0628\u0631\u0646\u0688\u06cc"
     ],
     "name:pol_x_preferred":[
+        "Burundi"
+    ],
+    "name:por_br_x_preferred":[
         "Burundi"
     ],
     "name:por_x_preferred":[
@@ -623,6 +653,9 @@
     "name:sme_x_preferred":[
         "Burundi"
     ],
+    "name:smo_x_preferred":[
+        "Burundi"
+    ],
     "name:sna_x_preferred":[
         "Burundi"
     ],
@@ -642,6 +675,12 @@
         "Burundi"
     ],
     "name:srd_x_preferred":[
+        "Burundi"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u0411\u0443\u0440\u0443\u043d\u0434\u0438"
+    ],
+    "name:srp_el_x_preferred":[
         "Burundi"
     ],
     "name:srp_x_preferred":[
@@ -664,6 +703,9 @@
     ],
     "name:szl_x_preferred":[
         "Bur\u016fndi"
+    ],
+    "name:szy_x_preferred":[
+        "Burundi"
     ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc1\u0bb0\u0bc1\u0ba3\u0bcd\u0b9f\u0bbf"
@@ -699,6 +741,9 @@
         "Burundi"
     ],
     "name:tur_x_preferred":[
+        "Burundi"
+    ],
+    "name:twi_x_preferred":[
         "Burundi"
     ],
     "name:udm_x_preferred":[
@@ -779,8 +824,17 @@
     "name:zha_x_preferred":[
         "Burundi"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u84b2\u9686\u5730"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u5e03\u9686\u8fea"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Burundi"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u84b2\u9686\u5730"
     ],
     "name:zho_x_preferred":[
         "\u84b2\u9686\u5730"
@@ -949,7 +1003,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1583797279,
+    "wof:lastmodified":1587428028,
     "wof:name":"Burundi",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.