### PR TITLE
bi concordances, placetype local, and more

### DIFF
--- a/data/110/875/930/5/1108759305.geojson
+++ b/data/110/875/930/5/1108759305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010068,
-    "geom:area_square_m":124249548.332114,
+    "geom:area_square_m":124249548.332107,
     "geom:bbox":"29.643768,-3.720205,29.80458,-3.559845",
     "geom:latitude":-3.626878,
     "geom:longitude":29.711656,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MW.BI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324406,
-    "wof:geomhash":"2f137aba39b73f1f3f9cedf809753d6d",
+    "wof:geomhash":"be70e824ac90bd3953f74b949c1f4b19",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759305,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886172,
     "wof:name":"Bisoro",
     "wof:parent_id":85668801,
     "wof:placetype":"county",

--- a/data/110/875/930/7/1108759307.geojson
+++ b/data/110/875/930/7/1108759307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017908,
-    "geom:area_square_m":221122252.899823,
+    "geom:area_square_m":221122252.899789,
     "geom:bbox":"29.288829,-3.162894,29.436326,-2.945545",
     "geom:latitude":-3.058997,
     "geom:longitude":29.365707,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BB.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324408,
-    "wof:geomhash":"e83740a97b7e9e44c6ec2d7f6691778a",
+    "wof:geomhash":"ca67d8b245713310f28da01238710d9f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108759307,
-    "wof:lastmodified":1636500687,
+    "wof:lastmodified":1695886764,
     "wof:name":"Bubanza",
     "wof:parent_id":85668739,
     "wof:placetype":"county",

--- a/data/110/875/930/9/1108759309.geojson
+++ b/data/110/875/930/9/1108759309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019731,
-    "geom:area_square_m":243752421.493725,
+    "geom:area_square_m":243752421.493699,
     "geom:bbox":"29.942829,-2.537766,30.100733,-2.327129",
     "geom:latitude":-2.429716,
     "geom:longitude":30.019506,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KI.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324409,
-    "wof:geomhash":"0b501847fae0c201fbba7e809ede2cda",
+    "wof:geomhash":"a72cbe56c6fe3b64fc60c414967337c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759309,
-    "wof:lastmodified":1627521592,
+    "wof:lastmodified":1695886172,
     "wof:name":"Bugabira",
     "wof:parent_id":85668783,
     "wof:placetype":"county",

--- a/data/110/875/931/3/1108759313.geojson
+++ b/data/110/875/931/3/1108759313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014483,
-    "geom:area_square_m":178840570.560382,
+    "geom:area_square_m":178840570.560474,
     "geom:bbox":"29.127366,-3.10391,29.303478,-2.873188",
     "geom:latitude":-2.990516,
     "geom:longitude":29.225914,
@@ -162,9 +162,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CI.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324410,
-    "wof:geomhash":"4c71ad932f92421b250a8e1bfd475d5f",
+    "wof:geomhash":"df918bf687cdaaaf814d67c35101d677",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1108759313,
-    "wof:lastmodified":1566614804,
+    "wof:lastmodified":1695886849,
     "wof:name":"Buganda",
     "wof:parent_id":85668749,
     "wof:placetype":"county",

--- a/data/110/875/931/5/1108759315.geojson
+++ b/data/110/875/931/5/1108759315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010563,
-    "geom:area_square_m":130336949.559928,
+    "geom:area_square_m":130336949.559971,
     "geom:bbox":"29.310495,-3.731394,29.499244,-3.642242",
     "geom:latitude":-3.690479,
     "geom:longitude":29.400409,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RU.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324411,
-    "wof:geomhash":"4cbf482245d56c3c8354085f534a0305",
+    "wof:geomhash":"50546f354fa143a1db43d49370433900",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759315,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886172,
     "wof:name":"Bugarama",
     "wof:parent_id":1108803107,
     "wof:placetype":"county",

--- a/data/110/875/931/7/1108759317.geojson
+++ b/data/110/875/931/7/1108759317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021943,
-    "geom:area_square_m":270886371.707959,
+    "geom:area_square_m":270886371.707915,
     "geom:bbox":"29.799672,-3.343328,30.028552,-3.155659",
     "geom:latitude":-3.256072,
     "geom:longitude":29.93403,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324413,
-    "wof:geomhash":"e490b91dc07b172db7585b762759d39a",
+    "wof:geomhash":"a9ec090e8d3ba0009582091cb6fac42d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759317,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886172,
     "wof:name":"Bugendana",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/931/9/1108759319.geojson
+++ b/data/110/875/931/9/1108759319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01797,
-    "geom:area_square_m":221881870.222324,
+    "geom:area_square_m":221881870.222424,
     "geom:bbox":"29.970813,-3.199286,30.153501,-2.984664",
     "geom:latitude":-3.078736,
     "geom:longitude":30.06062,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KR.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324414,
-    "wof:geomhash":"c051c3f4e3040d411312f43a4cc833b5",
+    "wof:geomhash":"8cd435f839bf004b666fa36692d86b49",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759319,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886172,
     "wof:name":"Bugenyuzi",
     "wof:parent_id":85668727,
     "wof:placetype":"county",

--- a/data/110/875/932/1/1108759321.geojson
+++ b/data/110/875/932/1/1108759321.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021394,
-    "geom:area_square_m":264154454.233378,
+    "geom:area_square_m":264154454.233389,
     "geom:bbox":"30.08102,-3.201842,30.277843,-2.975971",
     "geom:latitude":-3.085492,
     "geom:longitude":30.187614,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KR.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324415,
-    "wof:geomhash":"65e9c7f35c9015345ac997c2e4b70223",
+    "wof:geomhash":"7add4a29a4d096d2b47680590fbc09de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759321,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Buhiga",
     "wof:parent_id":85668727,
     "wof:placetype":"county",

--- a/data/110/875/932/3/1108759323.geojson
+++ b/data/110/875/932/3/1108759323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017339,
-    "geom:area_square_m":214103879.218806,
+    "geom:area_square_m":214103879.218828,
     "geom:bbox":"30.274595,-3.071769,30.436574,-2.89436",
     "geom:latitude":-2.98153,
     "geom:longitude":30.358794,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MY.BH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324416,
-    "wof:geomhash":"8f83845162c0a99b9ec015270d213e76",
+    "wof:geomhash":"ce4dd005530ffa747cc7c743dbb22778",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759323,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Buhinyuza",
     "wof:parent_id":85668787,
     "wof:placetype":"county",

--- a/data/110/875/932/5/1108759325.geojson
+++ b/data/110/875/932/5/1108759325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018134,
-    "geom:area_square_m":223679034.748204,
+    "geom:area_square_m":223679036.961025,
     "geom:bbox":"29.942844,-4.071244,30.230178,-3.959476",
     "geom:latitude":-4.023724,
     "geom:longitude":30.073913,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RT.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324417,
-    "wof:geomhash":"4e76a886e9401c7149bcc35a6f720891",
+    "wof:geomhash":"c8d84282767560996bef356fea817d93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759325,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Bukemba",
     "wof:parent_id":85668731,
     "wof:placetype":"county",

--- a/data/110/875/932/7/1108759327.geojson
+++ b/data/110/875/932/7/1108759327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014032,
-    "geom:area_square_m":173233241.049818,
+    "geom:area_square_m":173233241.049832,
     "geom:bbox":"29.522558,-3.260561,29.702911,-3.10749",
     "geom:latitude":-3.192886,
     "geom:longitude":29.604324,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MV.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324418,
-    "wof:geomhash":"7084b8aa6ddd2d7aa317f255074e339f",
+    "wof:geomhash":"6cfc3a80047c4b022ee750a1778eeee7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759327,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Bukeye",
     "wof:parent_id":85668797,
     "wof:placetype":"county",

--- a/data/110/875/933/1/1108759331.geojson
+++ b/data/110/875/933/1/1108759331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01891,
-    "geom:area_square_m":233529347.620459,
+    "geom:area_square_m":233529347.690987,
     "geom:bbox":"29.2422,-2.965971,29.477227,-2.783173",
     "geom:latitude":-2.877656,
     "geom:longitude":29.345058,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CI.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324419,
-    "wof:geomhash":"9047b3d321c215d57484f3a6b11b9310",
+    "wof:geomhash":"40acd20aa5e3e79f489e0a68be2e19dd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759331,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Bukinanyana",
     "wof:parent_id":85668749,
     "wof:placetype":"county",

--- a/data/110/875/933/3/1108759333.geojson
+++ b/data/110/875/933/3/1108759333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006703,
-    "geom:area_square_m":82711486.645827,
+    "geom:area_square_m":82711486.645838,
     "geom:bbox":"29.924323,-3.758889,30.020538,-3.646508",
     "geom:latitude":-3.701768,
     "geom:longitude":29.966754,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324421,
-    "wof:geomhash":"8707fe72b2b473085abed9dc7f67aa02",
+    "wof:geomhash":"80e0e398fc1c1e524358bbe24df229c4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759333,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Bukirasazi",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/933/5/1108759335.geojson
+++ b/data/110/875/933/5/1108759335.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022236,
-    "geom:area_square_m":274351041.728019,
+    "geom:area_square_m":274351041.727977,
     "geom:bbox":"29.357124,-3.925153,29.53519,-3.705421",
     "geom:latitude":-3.798641,
     "geom:longitude":29.452423,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RU.BM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324422,
-    "wof:geomhash":"a39dae8dc665ee444f0fc2eeaaa16ce1",
+    "wof:geomhash":"00f7b562ddd128bdecb2b7a21685603f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759335,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Burambi",
     "wof:parent_id":1108803107,
     "wof:placetype":"county",

--- a/data/110/875/933/7/1108759337.geojson
+++ b/data/110/875/933/7/1108759337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012012,
-    "geom:area_square_m":148216106.29529,
+    "geom:area_square_m":148216106.295322,
     "geom:bbox":"29.836538,-3.845078,29.997903,-3.685282",
     "geom:latitude":-3.756134,
     "geom:longitude":29.905967,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324423,
-    "wof:geomhash":"d47e240a792f5a59ec3280647aed81a8",
+    "wof:geomhash":"17191bd2ac816bdca3e421571e1be4b9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759337,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Buraza",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/933/9/1108759339.geojson
+++ b/data/110/875/933/9/1108759339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031358,
-    "geom:area_square_m":386823242.686496,
+    "geom:area_square_m":386823242.686495,
     "geom:bbox":"29.514058,-4.078728,29.809951,-3.886636",
     "geom:latitude":-3.963275,
     "geom:longitude":29.673862,
@@ -144,9 +144,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BI.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324424,
-    "wof:geomhash":"68f451a886c1e73e78ed4d648a15d714",
+    "wof:geomhash":"384c357beff0be073b11e105d39134b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108759339,
-    "wof:lastmodified":1636500688,
+    "wof:lastmodified":1695886764,
     "wof:name":"Bururi",
     "wof:parent_id":85668745,
     "wof:placetype":"county",

--- a/data/110/875/934/1/1108759341.geojson
+++ b/data/110/875/934/1/1108759341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01,
-    "geom:area_square_m":123492040.426634,
+    "geom:area_square_m":123492040.426651,
     "geom:bbox":"29.635974,-2.937505,29.766614,-2.790961",
     "geom:latitude":-2.857914,
     "geom:longitude":29.710086,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.NG.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324425,
-    "wof:geomhash":"ac8f217b54c42e7af1f6e28272cb4894",
+    "wof:geomhash":"92aef78beb8336708d1ac4598cdc7269",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759341,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Busiga",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/110/875/934/3/1108759343.geojson
+++ b/data/110/875/934/3/1108759343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034768,
-    "geom:area_square_m":429511062.002573,
+    "geom:area_square_m":429511062.002567,
     "geom:bbox":"30.103113,-2.621762,30.385448,-2.349049",
     "geom:latitude":-2.485815,
     "geom:longitude":30.239614,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KI.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324426,
-    "wof:geomhash":"bd7fdc59bed51e34bc3ca94f58194c20",
+    "wof:geomhash":"bd20a33acbe30e5a89738f817e67f200",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759343,
-    "wof:lastmodified":1627521593,
+    "wof:lastmodified":1695886173,
     "wof:name":"Busoni",
     "wof:parent_id":85668783,
     "wof:placetype":"county",

--- a/data/110/875/934/5/1108759345.geojson
+++ b/data/110/875/934/5/1108759345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02738,
-    "geom:area_square_m":337917570.109114,
+    "geom:area_square_m":337917570.109128,
     "geom:bbox":"30.05466,-3.683321,30.261056,-3.418524",
     "geom:latitude":-3.533299,
     "geom:longitude":30.148111,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RY.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324428,
-    "wof:geomhash":"f939877ab6ce4c443392c7aa4aa9081c",
+    "wof:geomhash":"a3269c2434d6deda73abbe05ee7f8369",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759345,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Butaganzwa1",
     "wof:parent_id":85668735,
     "wof:placetype":"county",

--- a/data/110/875/934/9/1108759349.geojson
+++ b/data/110/875/934/9/1108759349.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008136,
-    "geom:area_square_m":100452501.678245,
+    "geom:area_square_m":100452501.678212,
     "geom:bbox":"29.632406,-3.167516,29.775123,-3.049109",
     "geom:latitude":-3.10229,
     "geom:longitude":29.694791,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324429,
-    "wof:geomhash":"37dc3d4f54909e033dbc6e7358c4a384",
+    "wof:geomhash":"e4314f20f2e42dd9eeabba64c5b9d13f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759349,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Butaganzwa",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/935/1/1108759351.geojson
+++ b/data/110/875/935/1/1108759351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019892,
-    "geom:area_square_m":245547877.046431,
+    "geom:area_square_m":245547877.040964,
     "geom:bbox":"30.041065,-3.433373,30.341388,-3.275023",
     "geom:latitude":-3.364994,
     "geom:longitude":30.192332,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RY.BZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324430,
-    "wof:geomhash":"0b4784b93ac9002c7a43c45ec7b19a0a",
+    "wof:geomhash":"f7becefa58dbe69f36bc63e8ebae770a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759351,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Butezi",
     "wof:parent_id":85668735,
     "wof:placetype":"county",

--- a/data/110/875/935/3/1108759353.geojson
+++ b/data/110/875/935/3/1108759353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022535,
-    "geom:area_square_m":278336365.256322,
+    "geom:area_square_m":278336365.256371,
     "geom:bbox":"30.203924,-2.820977,30.434031,-2.597477",
     "geom:latitude":-2.71093,
     "geom:longitude":30.322362,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MY.BT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324431,
-    "wof:geomhash":"897156ae189054d56ff872cca6c67bf6",
+    "wof:geomhash":"5d20cf08d118b3b58e5ffdb3c4a85c1a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759353,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Butihinda",
     "wof:parent_id":85668787,
     "wof:placetype":"county",

--- a/data/110/875/935/5/1108759355.geojson
+++ b/data/110/875/935/5/1108759355.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016753,
-    "geom:area_square_m":206686087.077074,
+    "geom:area_square_m":206686087.077113,
     "geom:bbox":"29.448478,-3.982629,29.607332,-3.716176",
     "geom:latitude":-3.848742,
     "geom:longitude":29.532997,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RU.BY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324432,
-    "wof:geomhash":"dead4352613b136fe97eee3d3a4e7b56",
+    "wof:geomhash":"598a83533a9d57094c9b553cc01d6349",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759355,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Buyengero",
     "wof:parent_id":1108803107,
     "wof:placetype":"county",

--- a/data/110/875/935/7/1108759357.geojson
+++ b/data/110/875/935/7/1108759357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015093,
-    "geom:area_square_m":186442938.318753,
+    "geom:area_square_m":186442938.318778,
     "geom:bbox":"30.263166,-2.692925,30.41793,-2.412859",
     "geom:latitude":-2.552294,
     "geom:longitude":30.355591,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KI.BW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324433,
-    "wof:geomhash":"472096675f55af9cf8f06404fc0773c6",
+    "wof:geomhash":"bdebac03ffa57e98991fff133e8076ed",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759357,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Bwambarangwe",
     "wof:parent_id":85668783,
     "wof:placetype":"county",

--- a/data/110/875/935/9/1108759359.geojson
+++ b/data/110/875/935/9/1108759359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022425,
-    "geom:area_square_m":276829524.339231,
+    "geom:area_square_m":276829524.339277,
     "geom:bbox":"30.289535,-3.406316,30.54277,-3.206507",
     "geom:latitude":-3.306938,
     "geom:longitude":30.396453,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RY.BW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324434,
-    "wof:geomhash":"922f1bc2678647f60264f30f76add58a",
+    "wof:geomhash":"5cb2ce50b8bdf482e93a77e92022d730",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759359,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Bweru",
     "wof:parent_id":85668735,
     "wof:placetype":"county",

--- a/data/110/875/936/1/1108759361.geojson
+++ b/data/110/875/936/1/1108759361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026825,
-    "geom:area_square_m":331175280.040937,
+    "geom:area_square_m":331175271.425766,
     "geom:bbox":"30.363733,-3.31443,30.66806,-3.110642",
     "geom:latitude":-3.218905,
     "geom:longitude":30.523672,
@@ -108,9 +108,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CA.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324436,
-    "wof:geomhash":"b05840b9586cd54c6fbb0b9da7186dca",
+    "wof:geomhash":"36de68b937b6b6d3069cde1d8acaf845",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1108759361,
-    "wof:lastmodified":1636500686,
+    "wof:lastmodified":1695886763,
     "wof:name":"Cankuzo",
     "wof:parent_id":85668725,
     "wof:placetype":"county",

--- a/data/110/875/936/3/1108759363.geojson
+++ b/data/110/875/936/3/1108759363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014671,
-    "geom:area_square_m":181109244.518953,
+    "geom:area_square_m":181109244.518943,
     "geom:bbox":"30.519075,-3.396795,30.68769,-3.230171",
     "geom:latitude":-3.310538,
     "geom:longitude":30.60657,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CA.CE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324437,
-    "wof:geomhash":"01c63a30a9b77b1b74a5199edeaa73b5",
+    "wof:geomhash":"f8a3e45c7d3bbe32798c148c5dd1a963",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759363,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Cendajuru",
     "wof:parent_id":85668725,
     "wof:placetype":"county",

--- a/data/110/875/936/7/1108759367.geojson
+++ b/data/110/875/936/7/1108759367.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006357,
-    "geom:area_square_m":78497098.262259,
+    "geom:area_square_m":78497098.262295,
     "geom:bbox":"29.688117,-3.065697,29.768705,-2.913182",
     "geom:latitude":-2.99278,
     "geom:longitude":29.732465,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324438,
-    "wof:geomhash":"16bfa885827ad31bdaec5fc8cf4666ba",
+    "wof:geomhash":"dee8deea4a5966f1837df92cb367f448",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759367,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Gahombo",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/936/9/1108759369.geojson
+++ b/data/110/875/936/9/1108759369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010509,
-    "geom:area_square_m":129776419.274931,
+    "geom:area_square_m":129776419.274948,
     "geom:bbox":"29.835668,-2.971324,29.976198,-2.839823",
     "geom:latitude":-2.896168,
     "geom:longitude":29.909653,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.NG.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324439,
-    "wof:geomhash":"360a85ec962dc02ec3cd97684dd21bb5",
+    "wof:geomhash":"c6f68bab847f91d4471904e2d21c9490",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759369,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886174,
     "wof:name":"Gashikanwa",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/110/875/937/1/1108759371.geojson
+++ b/data/110/875/937/1/1108759371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012132,
-    "geom:area_square_m":149837791.620581,
+    "geom:area_square_m":149837791.620556,
     "geom:bbox":"30.077131,-2.857461,30.265886,-2.67713",
     "geom:latitude":-2.765893,
     "geom:longitude":30.173511,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MY.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324440,
-    "wof:geomhash":"c2686895c054539e27a35071b05b1b4f",
+    "wof:geomhash":"e74da84c5e5a2da96db2467564fad6de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759371,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886175,
     "wof:name":"Gashoho",
     "wof:parent_id":85668787,
     "wof:placetype":"county",

--- a/data/110/875/937/3/1108759373.geojson
+++ b/data/110/875/937/3/1108759373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01427,
-    "geom:area_square_m":176234319.145678,
+    "geom:area_square_m":176234319.145685,
     "geom:bbox":"30.153398,-2.925705,30.320716,-2.772475",
     "geom:latitude":-2.851156,
     "geom:longitude":30.235764,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MY.GW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324441,
-    "wof:geomhash":"45759696c4c9745f1b1226407de02673",
+    "wof:geomhash":"f67610344d6c3ed3ddd2da3289f13151",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759373,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886175,
     "wof:name":"Gasorwe",
     "wof:parent_id":85668787,
     "wof:placetype":"county",

--- a/data/110/875/937/5/1108759375.geojson
+++ b/data/110/875/937/5/1108759375.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008322,
-    "geom:area_square_m":102765795.967008,
+    "geom:area_square_m":102765795.967003,
     "geom:bbox":"29.629434,-3.073492,29.719528,-2.910069",
     "geom:latitude":-2.992259,
     "geom:longitude":29.677416,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.GT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324443,
-    "wof:geomhash":"467a03d438310a8ba0c5960e9eb750ff",
+    "wof:geomhash":"20c4758b1ecb1f9c69ac59c201fa0bab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759375,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886175,
     "wof:name":"Gatara",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/937/7/1108759377.geojson
+++ b/data/110/875/937/7/1108759377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022295,
-    "geom:area_square_m":275252899.819327,
+    "geom:area_square_m":275252899.819282,
     "geom:bbox":"29.222623,-3.31922,29.385703,-3.096447",
     "geom:latitude":-3.197397,
     "geom:longitude":29.294436,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BB.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324444,
-    "wof:geomhash":"ac3027924f501da0b208fa9df478d949",
+    "wof:geomhash":"de431d6bac6c880463ca414c467d7649",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759377,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886175,
     "wof:name":"Gihanga",
     "wof:parent_id":85668739,
     "wof:placetype":"county",

--- a/data/110/875/937/9/1108759379.geojson
+++ b/data/110/875/937/9/1108759379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045944,
-    "geom:area_square_m":566829409.991813,
+    "geom:area_square_m":566829409.992028,
     "geom:bbox":"30.056869,-4.005235,30.411067,-3.651277",
     "geom:latitude":-3.835444,
     "geom:longitude":30.234545,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RT.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324445,
-    "wof:geomhash":"2224a6f6835cf6424e04086e54980865",
+    "wof:geomhash":"5d2ed575667064b82c42fb8a7974f914",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759379,
-    "wof:lastmodified":1627521594,
+    "wof:lastmodified":1695886175,
     "wof:name":"Giharo",
     "wof:parent_id":85668731,
     "wof:placetype":"county",

--- a/data/110/875/938/1/1108759381.geojson
+++ b/data/110/875/938/1/1108759381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01239,
-    "geom:area_square_m":152939428.135334,
+    "geom:area_square_m":152939428.135347,
     "geom:bbox":"29.780164,-3.391866,29.992168,-3.269963",
     "geom:latitude":-3.336233,
     "geom:longitude":29.882025,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324446,
-    "wof:geomhash":"8b5424353d487c42af9d7f41332b8730",
+    "wof:geomhash":"8b27a21e94de72961b3fc8824a53cfcb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759381,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886175,
     "wof:name":"Giheta",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/938/5/1108759385.geojson
+++ b/data/110/875/938/5/1108759385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016026,
-    "geom:area_square_m":197867997.057235,
+    "geom:area_square_m":197867997.057195,
     "geom:bbox":"29.896781,-3.248101,30.061416,-3.044462",
     "geom:latitude":-3.141034,
     "geom:longitude":29.980185,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KR.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324448,
-    "wof:geomhash":"e88b7da2e2989fe949ce09e2ba13c771",
+    "wof:geomhash":"4bf661565a862bc6423279c8ffbd1678",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759385,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886175,
     "wof:name":"Gihogazi",
     "wof:parent_id":85668727,
     "wof:placetype":"county",

--- a/data/110/875/938/7/1108759387.geojson
+++ b/data/110/875/938/7/1108759387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026802,
-    "geom:area_square_m":330895928.588954,
+    "geom:area_square_m":330895928.588937,
     "geom:bbox":"30.6093,-3.320949,30.848867,-3.099343",
     "geom:latitude":-3.21329,
     "geom:longitude":30.737815,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CA.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324449,
-    "wof:geomhash":"19befd25804b4e17d6ab88b2cd51569f",
+    "wof:geomhash":"e17ae23971a999a439710abb0becf353",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759387,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886175,
     "wof:name":"Gisagara",
     "wof:parent_id":85668725,
     "wof:placetype":"county",

--- a/data/110/875/938/9/1108759389.geojson
+++ b/data/110/875/938/9/1108759389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01082,
-    "geom:area_square_m":133520376.227466,
+    "geom:area_square_m":133520376.227497,
     "geom:bbox":"29.833602,-3.697365,29.936637,-3.516361",
     "geom:latitude":-3.615297,
     "geom:longitude":29.890179,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.GB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324450,
-    "wof:geomhash":"3217569feffd4c075218fd29a9db1eeb",
+    "wof:geomhash":"f7836ebb1c22c839ee4163d1f3924cc9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759389,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886175,
     "wof:name":"Gishubi",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/939/1/1108759391.geojson
+++ b/data/110/875/939/1/1108759391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009561,
-    "geom:area_square_m":117993698.272859,
+    "geom:area_square_m":117993698.27287,
     "geom:bbox":"29.566116,-3.625855,29.713573,-3.476923",
     "geom:latitude":-3.55691,
     "geom:longitude":29.63371,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MW.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324451,
-    "wof:geomhash":"842d59958fc2ac0a9b72960344f21009",
+    "wof:geomhash":"8e368fbfb4a9a19d75acad76b96cace3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759391,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Gisozi",
     "wof:parent_id":85668801,
     "wof:placetype":"county",

--- a/data/110/875/939/3/1108759393.geojson
+++ b/data/110/875/939/3/1108759393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.042274,
-    "geom:area_square_m":521783803.564396,
+    "geom:area_square_m":521783803.564477,
     "geom:bbox":"30.342149,-3.579256,30.678121,-3.323255",
     "geom:latitude":-3.445958,
     "geom:longitude":30.498205,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RY.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324452,
-    "wof:geomhash":"fa94e1c84cd4890cc82f4f47ab880963",
+    "wof:geomhash":"c476a57975c5a46fc8cd3e8dbb4cfda5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759393,
-    "wof:lastmodified":1566614807,
+    "wof:lastmodified":1695886849,
     "wof:name":"Gisuru",
     "wof:parent_id":85668735,
     "wof:placetype":"county",

--- a/data/110/875/939/5/1108759395.geojson
+++ b/data/110/875/939/5/1108759395.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016735,
-    "geom:area_square_m":206650049.212042,
+    "geom:area_square_m":206650049.212066,
     "geom:bbox":"30.03844,-3.054796,30.279226,-2.904144",
     "geom:latitude":-2.975034,
     "geom:longitude":30.163167,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KR.GT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324454,
-    "wof:geomhash":"5b90c84bdb01681a12eae44358ce051a",
+    "wof:geomhash":"b2166b84dd366069916ee5869e0334d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759395,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Gitaramuka",
     "wof:parent_id":85668727,
     "wof:placetype":"county",

--- a/data/110/875/939/7/1108759397.geojson
+++ b/data/110/875/939/7/1108759397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024571,
-    "geom:area_square_m":303278256.335912,
+    "geom:area_square_m":303278256.335889,
     "geom:bbox":"29.847741,-3.520524,30.082668,-3.352788",
     "geom:latitude":-3.441196,
     "geom:longitude":29.957792,
@@ -201,9 +201,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.GG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324455,
-    "wof:geomhash":"3f5ef29f3b4714fed15a25b1c005004a",
+    "wof:geomhash":"d0cd737efa973fce5eee4e5862b0f5e1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -213,7 +214,7 @@
         }
     ],
     "wof:id":1108759397,
-    "wof:lastmodified":1636500687,
+    "wof:lastmodified":1695886764,
     "wof:name":"Gitega",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/939/9/1108759399.geojson
+++ b/data/110/875/939/9/1108759399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029661,
-    "geom:area_square_m":366422278.668207,
+    "geom:area_square_m":366422278.668216,
     "geom:bbox":"30.372354,-2.64061,30.543543,-2.30907",
     "geom:latitude":-2.45706,
     "geom:longitude":30.447854,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MY.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324456,
-    "wof:geomhash":"76de190584cd73dc633f04ec0f0d6d47",
+    "wof:geomhash":"49a1ece95b75200b78747bcd21482c0e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759399,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Giteranyi",
     "wof:parent_id":85668787,
     "wof:placetype":"county",

--- a/data/110/875/940/3/1108759403.geojson
+++ b/data/110/875/940/3/1108759403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01404,
-    "geom:area_square_m":173420928.314044,
+    "geom:area_square_m":173420928.314035,
     "geom:bbox":"30.144267,-2.736522,30.336387,-2.51808",
     "geom:latitude":-2.642072,
     "geom:longitude":30.22952,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KI.GI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324457,
-    "wof:geomhash":"475fef8dcb80df0499657a7178312695",
+    "wof:geomhash":"53772c38ea6b90ad06d9a63284f952a0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759403,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Gitobe",
     "wof:parent_id":85668783,
     "wof:placetype":"county",

--- a/data/110/875/940/5/1108759405.geojson
+++ b/data/110/875/940/5/1108759405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008809,
-    "geom:area_square_m":108741611.112802,
+    "geom:area_square_m":108741616.99621,
     "geom:bbox":"29.398599,-3.433284,29.541126,-3.29622",
     "geom:latitude":-3.363488,
     "geom:longitude":29.470307,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BL.IS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324458,
-    "wof:geomhash":"73eb5788f31e0222a7d977b7c7dced27",
+    "wof:geomhash":"c051b60dea9732345992439a297cbfd5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759405,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Isale",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/110/875/940/7/1108759407.geojson
+++ b/data/110/875/940/7/1108759407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017438,
-    "geom:area_square_m":215203098.487662,
+    "geom:area_square_m":215203098.4877,
     "geom:bbox":"29.973459,-3.724396,30.104959,-3.47261",
     "geom:latitude":-3.604429,
     "geom:longitude":30.047296,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.IT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324459,
-    "wof:geomhash":"a174746d3006868a1875577902dfe0f4",
+    "wof:geomhash":"563912b0c392f8c67acffc1faea0b73c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759407,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Itaba",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/940/9/1108759409.geojson
+++ b/data/110/875/940/9/1108759409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015467,
-    "geom:area_square_m":191011362.324127,
+    "geom:area_square_m":191011365.401706,
     "geom:bbox":"29.430283,-2.91729,29.668923,-2.786472",
     "geom:latitude":-2.846664,
     "geom:longitude":29.545803,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324460,
-    "wof:geomhash":"356a5750dfdfbe9bde176459f80c567d",
+    "wof:geomhash":"469329c94aecbe94b3f8393f3ee4a4a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108759409,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Kabarore",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/941/1/1108759411.geojson
+++ b/data/110/875/941/1/1108759411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005905,
-    "geom:area_square_m":72872118.430009,
+    "geom:area_square_m":72872120.654017,
     "geom:bbox":"29.33415,-3.595695,29.41706,-3.474916",
     "geom:latitude":-3.530587,
     "geom:longitude":29.369833,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BL.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324461,
-    "wof:geomhash":"c9d19ac8944b6822c0d8257c12962e0b",
+    "wof:geomhash":"f21eec31b9a2f152a7b486c92b1246bc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759411,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Kabezi",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/110/875/941/3/1108759413.geojson
+++ b/data/110/875/941/3/1108759413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006457,
-    "geom:area_square_m":79701847.621025,
+    "geom:area_square_m":79701832.763091,
     "geom:bbox":"29.37074,-3.485822,29.474231,-3.378191",
     "geom:latitude":-3.430745,
     "geom:longitude":29.415276,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BL.KY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324463,
-    "wof:geomhash":"890f99ed8d8e457faebb106fc78c8a57",
+    "wof:geomhash":"d6fcf1f8b0a4b32338869c1a01ff9c37",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759413,
-    "wof:lastmodified":1627521595,
+    "wof:lastmodified":1695886176,
     "wof:name":"Kanyosha1",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/110/875/941/5/1108759415.geojson
+++ b/data/110/875/941/5/1108759415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009642,
-    "geom:area_square_m":119069933.228777,
+    "geom:area_square_m":119069933.228723,
     "geom:bbox":"29.58249,-3.010978,29.712968,-2.859947",
     "geom:latitude":-2.918539,
     "geom:longitude":29.639736,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.KY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324464,
-    "wof:geomhash":"2e5cc1f75c09d0211bedf86e37850807",
+    "wof:geomhash":"9f1a7baf8e2c2b4b5efd69b92da1faf4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108759415,
-    "wof:lastmodified":1636500687,
+    "wof:lastmodified":1695886764,
     "wof:name":"Kayanza",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/941/7/1108759417.geojson
+++ b/data/110/875/941/7/1108759417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036957,
-    "geom:area_square_m":455786615.774255,
+    "geom:area_square_m":455786613.561506,
     "geom:bbox":"29.891771,-4.285195,30.191719,-4.039942",
     "geom:latitude":-4.150201,
     "geom:longitude":30.024338,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MA.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324465,
-    "wof:geomhash":"647cb3933fa406411e83859db10a1f10",
+    "wof:geomhash":"8ce4cdf90aab338f46541bdcd6b7be76",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759417,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886176,
     "wof:name":"Kayogoro",
     "wof:parent_id":85668763,
     "wof:placetype":"county",

--- a/data/110/875/942/1/1108759421.geojson
+++ b/data/110/875/942/1/1108759421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009129,
-    "geom:area_square_m":112672670.393549,
+    "geom:area_square_m":112672670.393538,
     "geom:bbox":"29.690141,-3.598758,29.814626,-3.445343",
     "geom:latitude":-3.522509,
     "geom:longitude":29.744312,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MW.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324467,
-    "wof:geomhash":"b9e4650dd8b9ebdc94df0d8cd6eda15d",
+    "wof:geomhash":"39049ef29e01ee6ef2e56a11b26c37d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759421,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886177,
     "wof:name":"Kayokwe",
     "wof:parent_id":85668801,
     "wof:placetype":"county",

--- a/data/110/875/942/3/1108759423.geojson
+++ b/data/110/875/942/3/1108759423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021697,
-    "geom:area_square_m":267539981.626455,
+    "geom:area_square_m":267539981.626426,
     "geom:bbox":"29.794217,-4.384136,30.004342,-4.191559",
     "geom:latitude":-4.290685,
     "geom:longitude":29.890949,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MA.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324469,
-    "wof:geomhash":"6fa15526920507e8634566d612956773",
+    "wof:geomhash":"ddb57d6dcc898a121194ad5e3b3f254f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759423,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886177,
     "wof:name":"Kibago",
     "wof:parent_id":85668763,
     "wof:placetype":"county",

--- a/data/110/875/942/5/1108759425.geojson
+++ b/data/110/875/942/5/1108759425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026687,
-    "geom:area_square_m":329523560.291094,
+    "geom:area_square_m":329523558.018386,
     "geom:bbox":"30.411012,-3.171652,30.671855,-2.892831",
     "geom:latitude":-3.030519,
     "geom:longitude":30.570822,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CA.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324470,
-    "wof:geomhash":"ab1b0513cadeb321c51018ed14599484",
+    "wof:geomhash":"79f4b7fca8ea881a4d701f9cc3b4a0e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759425,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886177,
     "wof:name":"Kigamba",
     "wof:parent_id":85668725,
     "wof:placetype":"county",

--- a/data/110/875/942/7/1108759427.geojson
+++ b/data/110/875/942/7/1108759427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008704,
-    "geom:area_square_m":107445843.696853,
+    "geom:area_square_m":107445843.696826,
     "geom:bbox":"29.627429,-3.426223,29.724424,-3.264529",
     "geom:latitude":-3.345779,
     "geom:longitude":29.672019,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MV.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324471,
-    "wof:geomhash":"568ad6c4649591054ed125c74a1e94f2",
+    "wof:geomhash":"1b9624e1910c54bd0f41a809d68fb8f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759427,
-    "wof:lastmodified":1566614818,
+    "wof:lastmodified":1695886850,
     "wof:name":"Kiganda",
     "wof:parent_id":85668797,
     "wof:placetype":"county",

--- a/data/110/875/942/9/1108759429.geojson
+++ b/data/110/875/942/9/1108759429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021839,
-    "geom:area_square_m":269501793.818642,
+    "geom:area_square_m":269501793.818492,
     "geom:bbox":"30.286529,-3.727752,30.458054,-3.496403",
     "geom:latitude":-3.624188,
     "geom:longitude":30.364488,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RY.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324472,
-    "wof:geomhash":"510e6f74f6123340baf64388a9fd3f14",
+    "wof:geomhash":"e0d2f3b45496a0584ff7fc8bdd665426",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759429,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886177,
     "wof:name":"Kinyinya",
     "wof:parent_id":85668735,
     "wof:placetype":"county",

--- a/data/110/875/943/1/1108759431.geojson
+++ b/data/110/875/943/1/1108759431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018715,
-    "geom:area_square_m":231129644.69195,
+    "geom:area_square_m":231129644.691907,
     "geom:bbox":"29.930015,-2.906184,30.136262,-2.753675",
     "geom:latitude":-2.836068,
     "geom:longitude":30.032446,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BI.NG.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324473,
-    "wof:geomhash":"b90ddc52486f6ed7006d463fdf2de6a9",
+    "wof:geomhash":"554f835b18df28193f1a201ff266988b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759431,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886177,
     "wof:name":"Kiremba",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/110/875/943/3/1108759433.geojson
+++ b/data/110/875/943/3/1108759433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018082,
-    "geom:area_square_m":223366522.36488,
+    "geom:area_square_m":223366522.364959,
     "geom:bbox":"30.028531,-2.666904,30.177167,-2.425",
     "geom:latitude":-2.558002,
     "geom:longitude":30.108472,
@@ -150,9 +150,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KI.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324474,
-    "wof:geomhash":"d600f46ab49e56b00059f0716159a07c",
+    "wof:geomhash":"ca444dbd774138c1f7db8493fb371254",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":1108759433,
-    "wof:lastmodified":1636500688,
+    "wof:lastmodified":1695886764,
     "wof:name":"Kirundo",
     "wof:parent_id":85668783,
     "wof:placetype":"county",

--- a/data/110/875/943/5/1108759435.geojson
+++ b/data/110/875/943/5/1108759435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022203,
-    "geom:area_square_m":273771741.73351,
+    "geom:area_square_m":273771741.733452,
     "geom:bbox":"29.709274,-4.470001,29.852262,-4.173084",
     "geom:latitude":-4.307305,
     "geom:longitude":29.768003,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MA.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324475,
-    "wof:geomhash":"9e7434ae97521d6f0cf67fd893e4dba3",
+    "wof:geomhash":"c2442a751b164a4ae708f755d0fbdb73",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759435,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886177,
     "wof:name":"Mabanda",
     "wof:parent_id":85668763,
     "wof:placetype":"county",

--- a/data/110/875/943/9/1108759439.geojson
+++ b/data/110/875/943/9/1108759439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016614,
-    "geom:area_square_m":205206843.715835,
+    "geom:area_square_m":205206843.553119,
     "geom:bbox":"29.149936,-2.836746,29.304231,-2.609588",
     "geom:latitude":-2.724012,
     "geom:longitude":29.229355,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CI.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324476,
-    "wof:geomhash":"6844cbd0376339bb14f7e3ec27a46a5b",
+    "wof:geomhash":"a2b51d38058fd6a87664e1512fe11bca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759439,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886178,
     "wof:name":"Mabayi",
     "wof:parent_id":85668749,
     "wof:placetype":"county",

--- a/data/110/875/944/1/1108759441.geojson
+++ b/data/110/875/944/1/1108759441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024771,
-    "geom:area_square_m":305499091.802264,
+    "geom:area_square_m":305499091.802271,
     "geom:bbox":"29.731763,-4.220997,29.921327,-4.002884",
     "geom:latitude":-4.125403,
     "geom:longitude":29.815434,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MA.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324478,
-    "wof:geomhash":"e11c225d767ca4298727aa2fba1506f4",
+    "wof:geomhash":"d37c313a33a966e98a64b71cd7d0cbb9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759441,
-    "wof:lastmodified":1636500688,
+    "wof:lastmodified":1695886764,
     "wof:name":"Makamba",
     "wof:parent_id":85668763,
     "wof:placetype":"county",

--- a/data/110/875/944/3/1108759443.geojson
+++ b/data/110/875/944/3/1108759443.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013802,
-    "geom:area_square_m":170332825.369611,
+    "geom:area_square_m":170332825.369646,
     "geom:bbox":"29.901836,-3.666482,30.017684,-3.487333",
     "geom:latitude":-3.572357,
     "geom:longitude":29.966593,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324479,
-    "wof:geomhash":"5e09e856e6519f45aa3dddc29e24a2ad",
+    "wof:geomhash":"05c46d854ae7c9e466c7d98cf4dee174",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759443,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886178,
     "wof:name":"Makebuko",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/944/5/1108759445.geojson
+++ b/data/110/875/944/5/1108759445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014124,
-    "geom:area_square_m":174445065.439763,
+    "geom:area_square_m":174445065.439765,
     "geom:bbox":"29.889541,-2.808321,30.052799,-2.655063",
     "geom:latitude":-2.734075,
     "geom:longitude":29.962137,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.NG.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324480,
-    "wof:geomhash":"b4b32eb7e80c39667ab3e20f00dae773",
+    "wof:geomhash":"03c10e4cec0946ab56542004f555e468",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759445,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886178,
     "wof:name":"Marangara",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/110/875/944/7/1108759447.geojson
+++ b/data/110/875/944/7/1108759447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016488,
-    "geom:area_square_m":203438364.614667,
+    "geom:area_square_m":203438364.614714,
     "geom:bbox":"29.614253,-3.840627,29.780803,-3.645762",
     "geom:latitude":-3.744836,
     "geom:longitude":29.714417,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BI.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324481,
-    "wof:geomhash":"d44a3473f89615fc3a51a7c288550c76",
+    "wof:geomhash":"b5cb2be827833b0b92546abf0230785c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759447,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886178,
     "wof:name":"Matana",
     "wof:parent_id":85668745,
     "wof:placetype":"county",

--- a/data/110/875/944/9/1108759449.geojson
+++ b/data/110/875/944/9/1108759449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012682,
-    "geom:area_square_m":156594554.936766,
+    "geom:area_square_m":156594551.457784,
     "geom:bbox":"29.533786,-3.167393,29.662408,-3.003353",
     "geom:latitude":-3.077223,
     "geom:longitude":29.603972,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324483,
-    "wof:geomhash":"6863b0c4bed2e235c12d9f8d804a3655",
+    "wof:geomhash":"3a260a2603880b2f473813c22954f899",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759449,
-    "wof:lastmodified":1627521596,
+    "wof:lastmodified":1695886178,
     "wof:name":"Matongo",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/945/1/1108759451.geojson
+++ b/data/110/875/945/1/1108759451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0095,
-    "geom:area_square_m":117286298.721529,
+    "geom:area_square_m":117286298.721525,
     "geom:bbox":"29.664829,-3.287245,29.851808,-3.191817",
     "geom:latitude":-3.240135,
     "geom:longitude":29.747115,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MV.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324484,
-    "wof:geomhash":"3e0413b03b8aee70b4ba71e7d8349290",
+    "wof:geomhash":"4782c1895c5089dca4dc3f6918d63b76",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759451,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886178,
     "wof:name":"Mbuye",
     "wof:parent_id":85668797,
     "wof:placetype":"county",

--- a/data/110/875/945/3/1108759453.geojson
+++ b/data/110/875/945/3/1108759453.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029727,
-    "geom:area_square_m":367050463.049125,
+    "geom:area_square_m":367050463.0491,
     "geom:bbox":"30.604253,-3.174021,30.850906,-2.9696",
     "geom:latitude":-3.066786,
     "geom:longitude":30.727587,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CA.MI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324485,
-    "wof:geomhash":"a1115c2e5640c7633b8e0313086b5874",
+    "wof:geomhash":"0825cdd3657adc15e48ee61158596a55",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759453,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886178,
     "wof:name":"Mishiha",
     "wof:parent_id":85668725,
     "wof:placetype":"county",

--- a/data/110/875/945/7/1108759457.geojson
+++ b/data/110/875/945/7/1108759457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009505,
-    "geom:area_square_m":117347991.965375,
+    "geom:area_square_m":117347991.965342,
     "geom:bbox":"29.343906,-3.264441,29.477172,-3.11256",
     "geom:latitude":-3.185867,
     "geom:longitude":29.408516,
@@ -126,9 +126,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BB.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324487,
-    "wof:geomhash":"936956f52fd77d7b423f7e2a2ddca18a",
+    "wof:geomhash":"d686967e8bfd85d3626613f4b9ff6416",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108759457,
-    "wof:lastmodified":1636500688,
+    "wof:lastmodified":1695886764,
     "wof:name":"Mpanda",
     "wof:parent_id":85668739,
     "wof:placetype":"county",

--- a/data/110/875/945/9/1108759459.geojson
+++ b/data/110/875/945/9/1108759459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023472,
-    "geom:area_square_m":289597897.634262,
+    "geom:area_square_m":289597897.634271,
     "geom:bbox":"30.051513,-3.950969,30.24463,-3.649637",
     "geom:latitude":-3.804894,
     "geom:longitude":30.139861,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RT.MP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324488,
-    "wof:geomhash":"22d123a75f22391588121330db878317",
+    "wof:geomhash":"c0fd63049bc71a5de8c89a5ea7a93a99",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759459,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886178,
     "wof:name":"Mpinga-Kayove",
     "wof:parent_id":85668731,
     "wof:placetype":"county",

--- a/data/110/875/946/1/1108759461.geojson
+++ b/data/110/875/946/1/1108759461.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005643,
-    "geom:area_square_m":69658704.533192,
+    "geom:area_square_m":69658704.533201,
     "geom:bbox":"29.42772,-3.341726,29.534042,-3.249048",
     "geom:latitude":-3.295743,
     "geom:longitude":29.484035,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BL.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324489,
-    "wof:geomhash":"79e270f01dcdb011f708f9d2748e68a8",
+    "wof:geomhash":"099950fbda451afa500070b3ca1da3f0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759461,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886178,
     "wof:name":"Mubimbi",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/110/875/946/3/1108759463.geojson
+++ b/data/110/875/946/3/1108759463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023463,
-    "geom:area_square_m":289535446.599143,
+    "geom:area_square_m":289535446.599142,
     "geom:bbox":"29.488738,-3.782758,29.678394,-3.557982",
     "geom:latitude":-3.670348,
     "geom:longitude":29.586604,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BI.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324490,
-    "wof:geomhash":"fdee78634d2e2d6985fb52434ac539f5",
+    "wof:geomhash":"ffe211f3a8fbfa72f77cc0c49ec98e17",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759463,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Mugamba",
     "wof:parent_id":85668745,
     "wof:placetype":"county",

--- a/data/110/875/946/5/1108759465.geojson
+++ b/data/110/875/946/5/1108759465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022881,
-    "geom:area_square_m":282611404.702704,
+    "geom:area_square_m":282611404.702628,
     "geom:bbox":"29.045468,-2.819129,29.216819,-2.590879",
     "geom:latitude":-2.692257,
     "geom:longitude":29.12169,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CI.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324491,
-    "wof:geomhash":"3d6743aae43bfabd8915d93e136fb8db",
+    "wof:geomhash":"9b48df9d73e9afacac2f6608668b0869",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759465,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Mugina",
     "wof:parent_id":85668749,
     "wof:placetype":"county",

--- a/data/110/875/946/7/1108759467.geojson
+++ b/data/110/875/946/7/1108759467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009064,
-    "geom:area_square_m":111875556.731774,
+    "geom:area_square_m":111875556.731788,
     "geom:bbox":"29.496127,-3.510268,29.598558,-3.340657",
     "geom:latitude":-3.441415,
     "geom:longitude":29.548534,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BL.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324492,
-    "wof:geomhash":"88e2817369c32f25214cdad95bc67461",
+    "wof:geomhash":"ddfe404e037ba5c1a1ad5b66ed4c3621",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759467,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Mugongomanga",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/110/875/946/9/1108759469.geojson
+++ b/data/110/875/946/9/1108759469.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003022,
-    "geom:area_square_m":37305097.851994,
+    "geom:area_square_m":37305096.763982,
     "geom:bbox":"29.329871,-3.485524,29.386557,-3.395865",
     "geom:latitude":-3.43674,
     "geom:longitude":29.358587,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BM.KY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324494,
-    "wof:geomhash":"8e482c0f460675d3418e2dcb1aedb38a",
+    "wof:geomhash":"1c891d72f60383a5f9ed60caaf391e4d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759469,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Muha",
     "wof:parent_id":85668791,
     "wof:placetype":"county",

--- a/data/110/875/947/1/1108759471.geojson
+++ b/data/110/875/947/1/1108759471.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009801,
-    "geom:area_square_m":121019234.228531,
+    "geom:area_square_m":121019234.228529,
     "geom:bbox":"29.746591,-3.102958,29.879236,-2.97561",
     "geom:latitude":-3.04449,
     "geom:longitude":29.803411,
@@ -147,9 +147,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.MH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324495,
-    "wof:geomhash":"de3a2652ce57dcd1858d1ff9f47bdeca",
+    "wof:geomhash":"fb8dd8ee0e7981a936bca8be80c261b7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108759471,
-    "wof:lastmodified":1566614812,
+    "wof:lastmodified":1695886850,
     "wof:name":"Muhanga",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/947/5/1108759475.geojson
+++ b/data/110/875/947/5/1108759475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010543,
-    "geom:area_square_m":130109860.375052,
+    "geom:area_square_m":130109860.375039,
     "geom:bbox":"29.335889,-3.67466,29.499908,-3.558816",
     "geom:latitude":-3.623513,
     "geom:longitude":29.415219,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RU.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324496,
-    "wof:geomhash":"c56c572dd09b9f14d9febb5bf2ee6469",
+    "wof:geomhash":"68b2bd03bde20defb550f7207731a395",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759475,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Muhuta",
     "wof:parent_id":1108803107,
     "wof:placetype":"county",

--- a/data/110/875/947/7/1108759477.geojson
+++ b/data/110/875/947/7/1108759477.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00148,
-    "geom:area_square_m":18268879.803396,
+    "geom:area_square_m":18268838.469976,
     "geom:bbox":"29.336072,-3.401418,29.403185,-3.362605",
     "geom:latitude":-3.382413,
     "geom:longitude":29.370585,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BM.RO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324497,
-    "wof:geomhash":"9042c3aef32e2627bdad0b40cd5a2b38",
+    "wof:geomhash":"c6948115d4b8b8071cc189c37c29049c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759477,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Mukaza",
     "wof:parent_id":85668791,
     "wof:placetype":"county",

--- a/data/110/875/947/9/1108759479.geojson
+++ b/data/110/875/947/9/1108759479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011542,
-    "geom:area_square_m":142443828.627901,
+    "geom:area_square_m":142443828.62787,
     "geom:bbox":"29.4442,-3.676085,29.589044,-3.486516",
     "geom:latitude":-3.564572,
     "geom:longitude":29.513916,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BL.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324498,
-    "wof:geomhash":"0da6a3cdc60d96ae02320c0387f30fea",
+    "wof:geomhash":"7bf2b6e6c5e0b1473bd3fcab99832904",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759479,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Mukike",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/110/875/948/1/1108759481.geojson
+++ b/data/110/875/948/1/1108759481.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015535,
-    "geom:area_square_m":191780267.137096,
+    "geom:area_square_m":191780267.137106,
     "geom:bbox":"29.502488,-3.399936,29.678041,-3.231581",
     "geom:latitude":-3.300947,
     "geom:longitude":29.587042,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MV.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324499,
-    "wof:geomhash":"b6c8c133b3dc267d2b217760bc59bd96",
+    "wof:geomhash":"894956138fa1e740e14c3f18e42f4e7b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108759481,
-    "wof:lastmodified":1636500687,
+    "wof:lastmodified":1695886764,
     "wof:name":"Muramvya",
     "wof:parent_id":85668797,
     "wof:placetype":"county",

--- a/data/110/875/948/3/1108759483.geojson
+++ b/data/110/875/948/3/1108759483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011565,
-    "geom:area_square_m":142813458.614155,
+    "geom:area_square_m":142813458.614158,
     "geom:bbox":"29.498447,-3.02877,29.613717,-2.878736",
     "geom:latitude":-2.956309,
     "geom:longitude":29.558883,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324500,
-    "wof:geomhash":"fca0d03e9627a1fae3efa367562b70e4",
+    "wof:geomhash":"4b11b0328d459447ffe492dae3d6c610",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759483,
-    "wof:lastmodified":1566614810,
+    "wof:lastmodified":1695886850,
     "wof:name":"Muruta",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/948/5/1108759485.geojson
+++ b/data/110/875/948/5/1108759485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020238,
-    "geom:area_square_m":249924499.25259,
+    "geom:area_square_m":249924499.252594,
     "geom:bbox":"29.136291,-3.009779,29.360132,-2.776736",
     "geom:latitude":-2.905328,
     "geom:longitude":29.248531,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CI.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324507,
-    "wof:geomhash":"43bea2442238b429612660561da650bb",
+    "wof:geomhash":"601da6133fd330438329346baed5ec4d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759485,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Murwi",
     "wof:parent_id":85668749,
     "wof:placetype":"county",

--- a/data/110/875/948/7/1108759487.geojson
+++ b/data/110/875/948/7/1108759487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014797,
-    "geom:area_square_m":182709732.059344,
+    "geom:area_square_m":182709732.059355,
     "geom:bbox":"29.383939,-3.158397,29.527889,-2.935853",
     "geom:latitude":-3.045141,
     "geom:longitude":29.456777,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BB.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324508,
-    "wof:geomhash":"0bec200b4aa0aaaac04807d4167e5027",
+    "wof:geomhash":"1443e515d43765a1e7a173eae4418555",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1108759487,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Musigati",
     "wof:parent_id":85668739,
     "wof:placetype":"county",

--- a/data/110/875/948/9/1108759489.geojson
+++ b/data/110/875/948/9/1108759489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019887,
-    "geom:area_square_m":245377651.819326,
+    "geom:area_square_m":245377651.819313,
     "geom:bbox":"29.973825,-3.894691,30.157445,-3.632638",
     "geom:latitude":-3.755145,
     "geom:longitude":30.069588,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RT.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324510,
-    "wof:geomhash":"7e6c5190f39edc1b7910eb52dd18786f",
+    "wof:geomhash":"d996e8b1c94a317002729ab7703e1d8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759489,
-    "wof:lastmodified":1627521597,
+    "wof:lastmodified":1695886179,
     "wof:name":"Musongati",
     "wof:parent_id":85668731,
     "wof:placetype":"county",

--- a/data/110/875/949/3/1108759493.geojson
+++ b/data/110/875/949/3/1108759493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012018,
-    "geom:area_square_m":148386898.020434,
+    "geom:area_square_m":148386898.020392,
     "geom:bbox":"29.808027,-3.232919,29.925489,-3.05869",
     "geom:latitude":-3.144877,
     "geom:longitude":29.866504,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324511,
-    "wof:geomhash":"20d47323c69152f4272c37dfa0afcd6c",
+    "wof:geomhash":"3416605c92f2ee35c1aa8e6712444cd3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759493,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886180,
     "wof:name":"Mutaho",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/949/5/1108759495.geojson
+++ b/data/110/875/949/5/1108759495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006585,
-    "geom:area_square_m":81274260.24205,
+    "geom:area_square_m":81274260.24203,
     "geom:bbox":"29.376918,-3.591856,29.49438,-3.461878",
     "geom:latitude":-3.5285,
     "geom:longitude":29.43279,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BL.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324512,
-    "wof:geomhash":"6623174c80dfbd3c337bce86f786136e",
+    "wof:geomhash":"51501acc7f897ea5ed7f9e5529592282",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759495,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886180,
     "wof:name":"Mutambu",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/110/875/949/7/1108759497.geojson
+++ b/data/110/875/949/7/1108759497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012677,
-    "geom:area_square_m":156508232.653982,
+    "geom:area_square_m":156508214.446699,
     "geom:bbox":"30.169889,-3.31992,30.349889,-3.122261",
     "geom:latitude":-3.193563,
     "geom:longitude":30.244207,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KR.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324514,
-    "wof:geomhash":"40e5cf67bbec1c60c74482422399522e",
+    "wof:geomhash":"c64d515c9b4af9169e4adeb5e4a1bb47",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759497,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886180,
     "wof:name":"Mutumba",
     "wof:parent_id":85668727,
     "wof:placetype":"county",

--- a/data/110/875/949/9/1108759499.geojson
+++ b/data/110/875/949/9/1108759499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03011,
-    "geom:area_square_m":371865748.643768,
+    "geom:area_square_m":371865748.643755,
     "geom:bbox":"30.248597,-2.963352,30.530062,-2.653022",
     "geom:latitude":-2.809402,
     "geom:longitude":30.382719,
@@ -144,9 +144,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MY.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324520,
-    "wof:geomhash":"f0e76570a1dfcad5414edd4bb7e88480",
+    "wof:geomhash":"85bcd8755e74e85b0e476be08d36f799",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":1108759499,
-    "wof:lastmodified":1636500687,
+    "wof:lastmodified":1695886764,
     "wof:name":"Muyinga",
     "wof:parent_id":85668787,
     "wof:placetype":"county",

--- a/data/110/875/950/1/1108759501.geojson
+++ b/data/110/875/950/1/1108759501.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011496,
-    "geom:area_square_m":141946010.492411,
+    "geom:area_square_m":141946010.492385,
     "geom:bbox":"30.23068,-3.154604,30.390294,-3.021723",
     "geom:latitude":-3.092484,
     "geom:longitude":30.299998,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MY.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324521,
-    "wof:geomhash":"08908f1c6c0ce82012d481ad52b6518b",
+    "wof:geomhash":"394bec8f5bfe1e9f3acfc1a7808308d0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759501,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886180,
     "wof:name":"Mwakiro",
     "wof:parent_id":85668787,
     "wof:placetype":"county",

--- a/data/110/875/950/3/1108759503.geojson
+++ b/data/110/875/950/3/1108759503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009663,
-    "geom:area_square_m":119344628.459408,
+    "geom:area_square_m":119344628.459397,
     "geom:bbox":"29.751176,-2.887007,29.853029,-2.757068",
     "geom:latitude":-2.824435,
     "geom:longitude":29.800495,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.NG.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324523,
-    "wof:geomhash":"156168961b9dcb31faf18a3f4da7bd03",
+    "wof:geomhash":"0db14e95c6afa7f7b4c752c102f302ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759503,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886180,
     "wof:name":"Mwumba",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/110/875/950/5/1108759505.geojson
+++ b/data/110/875/950/5/1108759505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013685,
-    "geom:area_square_m":168916717.983154,
+    "geom:area_square_m":168916717.983184,
     "geom:bbox":"29.655479,-3.480119,29.840318,-3.297831",
     "geom:latitude":-3.391557,
     "geom:longitude":29.753431,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MW.ND"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324524,
-    "wof:geomhash":"0b5ccd757a9f071ce1fbea7ab0f1315f",
+    "wof:geomhash":"8f251c9f93969ff1028ae7fc0f57de45",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759505,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886180,
     "wof:name":"Ndava",
     "wof:parent_id":85668801,
     "wof:placetype":"county",

--- a/data/110/875/950/7/1108759507.geojson
+++ b/data/110/875/950/7/1108759507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005393,
-    "geom:area_square_m":66575113.370174,
+    "geom:area_square_m":66575194.250311,
     "geom:bbox":"29.306256,-3.377983,29.425915,-3.30321",
     "geom:latitude":-3.338581,
     "geom:longitude":29.365459,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BM.KM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324525,
-    "wof:geomhash":"b08d12f22238bf7e746206e7f1915d97",
+    "wof:geomhash":"f1828db281b942e7bd2272ec4b95d64c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759507,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886180,
     "wof:name":"Ntahangwa",
     "wof:parent_id":85668791,
     "wof:placetype":"county",

--- a/data/110/875/951/1/1108759511.geojson
+++ b/data/110/875/951/1/1108759511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020028,
-    "geom:area_square_m":247391955.145242,
+    "geom:area_square_m":247391955.145223,
     "geom:bbox":"29.920284,-2.69101,30.08839,-2.479533",
     "geom:latitude":-2.590176,
     "geom:longitude":29.991112,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KI.NT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324527,
-    "wof:geomhash":"3c081f232626e3f56b680b4eb431c54a",
+    "wof:geomhash":"c890a5753fa994427dc2b30c22c96154",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759511,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886181,
     "wof:name":"Ntega",
     "wof:parent_id":85668783,
     "wof:placetype":"county",

--- a/data/110/875/951/3/1108759513.geojson
+++ b/data/110/875/951/3/1108759513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011202,
-    "geom:area_square_m":138264505.002349,
+    "geom:area_square_m":138264505.002342,
     "geom:bbox":"29.735938,-3.528744,29.875007,-3.366646",
     "geom:latitude":-3.449181,
     "geom:longitude":29.812064,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MW.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324529,
-    "wof:geomhash":"d71afe8950457c54ec9d4b386dd380f0",
+    "wof:geomhash":"3f089f13599a2d03f0ae7ff743399eec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759513,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886181,
     "wof:name":"Nyabihanga",
     "wof:parent_id":85668801,
     "wof:placetype":"county",

--- a/data/110/875/951/5/1108759515.geojson
+++ b/data/110/875/951/5/1108759515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015129,
-    "geom:area_square_m":186765997.48153,
+    "geom:area_square_m":186765997.481476,
     "geom:bbox":"30.065528,-3.348748,30.208875,-3.156183",
     "geom:latitude":-3.264656,
     "geom:longitude":30.14117,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KR.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324531,
-    "wof:geomhash":"2ddf88d3b686dd0861b836e16b6fa866",
+    "wof:geomhash":"1f4a7d9f3596f08760b448467486b150",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759515,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886181,
     "wof:name":"Nyabikere",
     "wof:parent_id":85668727,
     "wof:placetype":"county",

--- a/data/110/875/951/7/1108759517.geojson
+++ b/data/110/875/951/7/1108759517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006385,
-    "geom:area_square_m":78805707.066194,
+    "geom:area_square_m":78805707.066179,
     "geom:bbox":"29.426982,-3.517406,29.519199,-3.385426",
     "geom:latitude":-3.457596,
     "geom:longitude":29.475245,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BL.NB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324532,
-    "wof:geomhash":"0269050044ae31bea68292cb38504556",
+    "wof:geomhash":"6d58bf50c60c4c72e406742c30b76021",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759517,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886181,
     "wof:name":"Nyabiraba",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/110/875/951/9/1108759519.geojson
+++ b/data/110/875/951/9/1108759519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017855,
-    "geom:area_square_m":220350293.066132,
+    "geom:area_square_m":220350293.066148,
     "geom:bbox":"30.153249,-3.693304,30.363494,-3.46135",
     "geom:latitude":-3.578129,
     "geom:longitude":30.270374,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RY.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324533,
-    "wof:geomhash":"bc0a770f5aab98e1fd68a6f49a34c276",
+    "wof:geomhash":"84a6f8c184524b00e9304f4319a1d24c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759519,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886181,
     "wof:name":"Nyabitsinda",
     "wof:parent_id":85668735,
     "wof:placetype":"county",

--- a/data/110/875/952/1/1108759521.geojson
+++ b/data/110/875/952/1/1108759521.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00755,
-    "geom:area_square_m":93248491.390435,
+    "geom:area_square_m":93248491.390431,
     "geom:bbox":"29.834504,-2.866756,29.937433,-2.749417",
     "geom:latitude":-2.813086,
     "geom:longitude":29.880914,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.NG.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324534,
-    "wof:geomhash":"e690a07a0c00c1c6d2758c4263e52c2a",
+    "wof:geomhash":"9a79fa4a4d4d3fe1e8bd98d6b7672615",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759521,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886181,
     "wof:name":"Nyamurenza",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/110/875/952/3/1108759523.geojson
+++ b/data/110/875/952/3/1108759523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009467,
-    "geom:area_square_m":116830202.317697,
+    "geom:area_square_m":116830202.31768,
     "geom:bbox":"29.76947,-3.650064,29.908092,-3.509918",
     "geom:latitude":-3.568078,
     "geom:longitude":29.830186,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.NS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324535,
-    "wof:geomhash":"c25c61f084085f03af79d9ae7688ea77",
+    "wof:geomhash":"d9ea297079df9e3bb6f91d0331ce9e05",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759523,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886181,
     "wof:name":"Nyanrusange",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/952/5/1108759525.geojson
+++ b/data/110/875/952/5/1108759525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030075,
-    "geom:area_square_m":370838884.134385,
+    "geom:area_square_m":370838884.134267,
     "geom:bbox":"29.536874,-4.462447,29.736875,-4.156426",
     "geom:latitude":-4.302253,
     "geom:longitude":29.646543,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MA.NL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324536,
-    "wof:geomhash":"57e6ac5ef9d69da3cb94c6e2084c5c1f",
+    "wof:geomhash":"ab0f7d227925eee6b0cbed0ef3676e41",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759525,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886181,
     "wof:name":"Nyanza-Lac",
     "wof:parent_id":85668763,
     "wof:placetype":"county",

--- a/data/110/875/952/9/1108759529.geojson
+++ b/data/110/875/952/9/1108759529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014141,
-    "geom:area_square_m":174591209.091739,
+    "geom:area_square_m":174591209.091722,
     "geom:bbox":"29.674363,-3.22926,29.851285,-3.088094",
     "geom:latitude":-3.155712,
     "geom:longitude":29.762118,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KY.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324537,
-    "wof:geomhash":"b2ce4219e0d6320bbf974a99e388fe98",
+    "wof:geomhash":"2f8569dd77c534ad8cfbc178352f5f8a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108759529,
-    "wof:lastmodified":1566614808,
+    "wof:lastmodified":1695886849,
     "wof:name":"Rango",
     "wof:parent_id":85668757,
     "wof:placetype":"county",

--- a/data/110/875/953/1/1108759531.geojson
+++ b/data/110/875/953/1/1108759531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01058,
-    "geom:area_square_m":130617040.902325,
+    "geom:area_square_m":130617042.523671,
     "geom:bbox":"29.400979,-3.271493,29.536525,-3.138813",
     "geom:latitude":-3.21104,
     "geom:longitude":29.475553,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BB.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324539,
-    "wof:geomhash":"0ee80b0d4cbe40ccb181995675acf05f",
+    "wof:geomhash":"a4d1898248be882bb5b2fe4766330abb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759531,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886181,
     "wof:name":"Rugazi",
     "wof:parent_id":85668739,
     "wof:placetype":"county",

--- a/data/110/875/953/3/1108759533.geojson
+++ b/data/110/875/953/3/1108759533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016338,
-    "geom:area_square_m":201778623.403608,
+    "geom:area_square_m":201778623.403613,
     "geom:bbox":"29.000345,-2.934458,29.216876,-2.722554",
     "geom:latitude":-2.82166,
     "geom:longitude":29.094503,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.CI.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324540,
-    "wof:geomhash":"6d08ed879d6d1a2399d2cef50cc0b5de",
+    "wof:geomhash":"14f6c8e7d124af104dd926a865c7f700",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759533,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Rugombo",
     "wof:parent_id":85668749,
     "wof:placetype":"county",

--- a/data/110/875/953/5/1108759535.geojson
+++ b/data/110/875/953/5/1108759535.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01296,
-    "geom:area_square_m":160034494.047296,
+    "geom:area_square_m":160034494.047247,
     "geom:bbox":"29.861579,-3.0876,30.020824,-2.933979",
     "geom:latitude":-3.008288,
     "geom:longitude":29.941379,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.NG.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324542,
-    "wof:geomhash":"7f37d43e26a28989f6e5fca68edbe4dc",
+    "wof:geomhash":"8b87a04db3d2671f32216d9f5e708fe2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759535,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Ruhororo",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/110/875/953/7/1108759537.geojson
+++ b/data/110/875/953/7/1108759537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025586,
-    "geom:area_square_m":315620717.002287,
+    "geom:area_square_m":315620717.002173,
     "geom:bbox":"29.312171,-4.19135,29.560771,-3.720684",
     "geom:latitude":-3.962211,
     "geom:longitude":29.457113,
@@ -102,9 +102,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RU.RM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324543,
-    "wof:geomhash":"0092296f3a632737d0c88cd90908b272",
+    "wof:geomhash":"ad815852842d05c35e59d79723054389",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1108759537,
-    "wof:lastmodified":1566614806,
+    "wof:lastmodified":1695886849,
     "wof:name":"Rumonge",
     "wof:parent_id":1108803107,
     "wof:placetype":"county",

--- a/data/110/875/953/9/1108759539.geojson
+++ b/data/110/875/953/9/1108759539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013158,
-    "geom:area_square_m":162408502.060935,
+    "geom:area_square_m":162408502.060943,
     "geom:bbox":"29.57756,-3.541614,29.707176,-3.348588",
     "geom:latitude":-3.454021,
     "geom:longitude":29.635205,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MW.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324544,
-    "wof:geomhash":"a1c1a926421c032b6d5c918d0b6ed574",
+    "wof:geomhash":"323dca625c164e4135c5cbae47ba389d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759539,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Rusaka",
     "wof:parent_id":85668801,
     "wof:placetype":"county",

--- a/data/110/875/954/1/1108759541.geojson
+++ b/data/110/875/954/1/1108759541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006434,
-    "geom:area_square_m":79429465.476161,
+    "geom:area_square_m":79429465.476166,
     "geom:bbox":"29.695514,-3.371844,29.810022,-3.252579",
     "geom:latitude":-3.315532,
     "geom:longitude":29.744079,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MV.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324546,
-    "wof:geomhash":"78fb7226dc57798d1b035d481d28ed8a",
+    "wof:geomhash":"20b6eb07e8cd449b0d019f1f32c89bd0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759541,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Rutegama",
     "wof:parent_id":85668797,
     "wof:placetype":"county",

--- a/data/110/875/954/3/1108759543.geojson
+++ b/data/110/875/954/3/1108759543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022868,
-    "geom:area_square_m":282122647.461331,
+    "geom:area_square_m":282122647.461347,
     "geom:bbox":"29.745702,-4.041638,29.916166,-3.726218",
     "geom:latitude":-3.878173,
     "geom:longitude":29.831989,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BI.RT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324547,
-    "wof:geomhash":"428dfc875d8b2a9bba0b9c7f7408cdef",
+    "wof:geomhash":"85e6fead7c03b35c019a09a6fd1a34ae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108759543,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Rutovu",
     "wof:parent_id":85668745,
     "wof:placetype":"county",

--- a/data/110/875/954/7/1108759547.geojson
+++ b/data/110/875/954/7/1108759547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022114,
-    "geom:area_square_m":272946576.484298,
+    "geom:area_square_m":272946576.484348,
     "geom:bbox":"30.171235,-3.526375,30.396674,-3.346972",
     "geom:latitude":-3.436853,
     "geom:longitude":30.278775,
@@ -135,9 +135,10 @@
     "wof:concordances":{
         "hasc:id":"BI.RY.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324548,
-    "wof:geomhash":"0d3daf95ea27606821833f02881aa1c5",
+    "wof:geomhash":"f95bf94a8db5ca9c957678a9ba292e2f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108759547,
-    "wof:lastmodified":1636500686,
+    "wof:lastmodified":1695886763,
     "wof:name":"Ruyigi",
     "wof:parent_id":85668735,
     "wof:placetype":"county",

--- a/data/110/875/954/9/1108759549.geojson
+++ b/data/110/875/954/9/1108759549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013313,
-    "geom:area_square_m":164278192.899458,
+    "geom:area_square_m":164278192.899479,
     "geom:bbox":"29.717616,-3.828033,29.876521,-3.616169",
     "geom:latitude":-3.707269,
     "geom:longitude":29.798799,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.GI.RY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324549,
-    "wof:geomhash":"fa6f7c1a2311394fd2029d4e5353791b",
+    "wof:geomhash":"3d91643f32e8283fd41f4cd252f2578a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759549,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Ryansoro",
     "wof:parent_id":85668753,
     "wof:placetype":"county",

--- a/data/110/875/955/1/1108759551.geojson
+++ b/data/110/875/955/1/1108759551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013404,
-    "geom:area_square_m":165471864.793732,
+    "geom:area_square_m":165471864.793787,
     "geom:bbox":"29.981284,-3.393871,30.118448,-3.170613",
     "geom:latitude":-3.285236,
     "geom:longitude":30.053915,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KR.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324551,
-    "wof:geomhash":"5e84b61c321b5e9328f5e8861edc0fd6",
+    "wof:geomhash":"f1b93cb0ff1c02024cf071cb3dd1b7b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759551,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Shombo",
     "wof:parent_id":85668727,
     "wof:placetype":"county",

--- a/data/110/875/955/3/1108759553.geojson
+++ b/data/110/875/955/3/1108759553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017954,
-    "geom:area_square_m":221502732.296753,
+    "geom:area_square_m":221502732.296813,
     "geom:bbox":"29.558219,-3.912503,29.785829,-3.777502",
     "geom:latitude":-3.85336,
     "geom:longitude":29.667589,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BI.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324552,
-    "wof:geomhash":"1e6a5fdd3c962de71ca9a11bdd440dc2",
+    "wof:geomhash":"1d4f52f541a46d21d82b3b21a2b18163",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759553,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Songa",
     "wof:parent_id":85668745,
     "wof:placetype":"county",

--- a/data/110/875/955/5/1108759555.geojson
+++ b/data/110/875/955/5/1108759555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016514,
-    "geom:area_square_m":203928202.392634,
+    "geom:area_square_m":203928202.392631,
     "geom:bbox":"29.943687,-2.989526,30.193385,-2.839452",
     "geom:latitude":-2.920374,
     "geom:longitude":30.07586,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"BI.NG.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324554,
-    "wof:geomhash":"13d12cdee3cde2d8d739135647f1a3e0",
+    "wof:geomhash":"0084e08f8ad7f85b6634724046303e9d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108759555,
-    "wof:lastmodified":1566614809,
+    "wof:lastmodified":1695886849,
     "wof:name":"Tangara",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/110/875/955/7/1108759557.geojson
+++ b/data/110/875/955/7/1108759557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0181,
-    "geom:area_square_m":223220368.979559,
+    "geom:area_square_m":223220368.979599,
     "geom:bbox":"29.568832,-4.262316,29.755418,-4.062257",
     "geom:latitude":-4.153846,
     "geom:longitude":29.678495,
@@ -63,9 +63,10 @@
     "wof:concordances":{
         "hasc:id":"BI.MA.VU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324556,
-    "wof:geomhash":"b6c099fc0ea405388788c972b1eccaba",
+    "wof:geomhash":"b1b82d788e55e161cc6b2f34b81706e4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108759557,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Vugizo",
     "wof:parent_id":85668763,
     "wof:placetype":"county",

--- a/data/110/875/955/9/1108759559.geojson
+++ b/data/110/875/955/9/1108759559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015807,
-    "geom:area_square_m":195236511.871266,
+    "geom:area_square_m":195236511.87128,
     "geom:bbox":"30.005761,-2.784194,30.191089,-2.604599",
     "geom:latitude":-2.700838,
     "geom:longitude":30.093543,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"BI.KI.VU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324558,
-    "wof:geomhash":"1470612b425ed1f2087d8d71fa0e303d",
+    "wof:geomhash":"21532ea0b67ae35c61f2bc40e5c30cf5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108759559,
-    "wof:lastmodified":1627521599,
+    "wof:lastmodified":1695886182,
     "wof:name":"Vumbi",
     "wof:parent_id":85668783,
     "wof:placetype":"county",

--- a/data/110/875/956/1/1108759561.geojson
+++ b/data/110/875/956/1/1108759561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018024,
-    "geom:area_square_m":222313442.781613,
+    "geom:area_square_m":222313442.781604,
     "geom:bbox":"29.517783,-4.161577,29.690551,-3.991374",
     "geom:latitude":-4.069808,
     "geom:longitude":29.596384,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"BI.BI.VY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1481324559,
-    "wof:geomhash":"5b270bbe9ebb8f105a98ddc9e9d4c065",
+    "wof:geomhash":"d9e3116392875d87bd38bb259dd44420",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108759561,
-    "wof:lastmodified":1566614815,
+    "wof:lastmodified":1695886850,
     "wof:name":"Vyanda",
     "wof:parent_id":85668745,
     "wof:placetype":"county",

--- a/data/110/880/310/7/1108803107.geojson
+++ b/data/110/880/310/7/1108803107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085681,
-    "geom:area_square_m":1057104655.742223,
+    "geom:area_square_m":1057104656.383815,
     "geom:bbox":"29.310495,-4.19135,29.607332,-3.558816",
     "geom:latitude":-3.822398,
     "geom:longitude":29.458588,
@@ -127,12 +127,14 @@
     "wof:breaches":[],
     "wof:concordances":{
         "hasc:id":"BI.RU",
+        "iso:code":"BI-RM",
         "iso:id":"BI-RM",
         "wd:id":"Q20669646"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:created":1485278604,
-    "wof:geomhash":"b6aaf416397279ea97807bd117415bec",
+    "wof:geomhash":"139a70ea70227fc2b0faae894fc7f48a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +151,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857394,
+    "wof:lastmodified":1695884484,
     "wof:name":"Rumonge",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/421/193/019/421193019.geojson
+++ b/data/421/193/019/421193019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021908,
-    "geom:area_square_m":270235065.730793,
+    "geom:area_square_m":270235065.730821,
     "geom:bbox":"29.813434,-4.097801,30.018314,-3.877507",
     "geom:latitude":-4.007563,
     "geom:longitude":29.901988,
@@ -378,12 +378,13 @@
         "qs_pg:id":97146,
         "wd:id":"Q167551"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1459009757,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6b3dd702872b6526c0c472c8292481a8",
+    "wof:geomhash":"d06cee34e5b7ae1e975925fda267877f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -393,7 +394,7 @@
         }
     ],
     "wof:id":421193019,
-    "wof:lastmodified":1690857396,
+    "wof:lastmodified":1695886784,
     "wof:name":"Gitanga",
     "wof:parent_id":85668731,
     "wof:placetype":"county",

--- a/data/421/196/575/421196575.geojson
+++ b/data/421/196/575/421196575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021122,
-    "geom:area_square_m":260582889.106216,
+    "geom:area_square_m":260582889.106207,
     "geom:bbox":"29.890106,-3.988693,30.059703,-3.767638",
     "geom:latitude":-3.886803,
     "geom:longitude":29.983377,
@@ -239,12 +239,13 @@
         "qs_pg:id":784355,
         "wd:id":"Q246069"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1459009886,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc1c47c0cace6bc4ada67b47e61e7d26",
+    "wof:geomhash":"ec3cbe790a28ca9b531c3e1213a8c18d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -254,7 +255,7 @@
         }
     ],
     "wof:id":421196575,
-    "wof:lastmodified":1690857399,
+    "wof:lastmodified":1695886764,
     "wof:name":"Rutana",
     "wof:parent_id":85668731,
     "wof:placetype":"county",

--- a/data/421/201/115/421201115.geojson
+++ b/data/421/201/115/421201115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014679,
-    "geom:area_square_m":181270534.822062,
+    "geom:area_square_m":181270534.822048,
     "geom:bbox":"29.748185,-3.017148,29.928083,-2.882509",
     "geom:latitude":-2.950272,
     "geom:longitude":29.826904,
@@ -122,12 +122,13 @@
         "hasc:id":"BI.NG.NG",
         "qs_pg:id":911965
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1459010051,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"43094e28ca62f336bd2e66ff0899d60c",
+    "wof:geomhash":"941404ccffb6ea86869581fa04f8b6fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421201115,
-    "wof:lastmodified":1636500693,
+    "wof:lastmodified":1695886764,
     "wof:name":"Ngozi",
     "wof:parent_id":85668781,
     "wof:placetype":"county",

--- a/data/421/204/423/421204423.geojson
+++ b/data/421/204/423/421204423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011477,
-    "geom:area_square_m":141684165.529597,
+    "geom:area_square_m":141684145.208898,
     "geom:bbox":"29.211046,-3.359957,29.444312,-3.255562",
     "geom:latitude":-3.30424,
     "geom:longitude":29.321196,
@@ -87,12 +87,13 @@
         "hasc:id":"BI.BL.MZ",
         "qs_pg:id":1307303
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BI",
     "wof:created":1459010185,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d028867512278c3edcef4d396156045f",
+    "wof:geomhash":"ecf288292cb2bf7bbb8c7a60388a5416",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":421204423,
-    "wof:lastmodified":1627521598,
+    "wof:lastmodified":1695886180,
     "wof:name":"Mutimbuzi",
     "wof:parent_id":85668799,
     "wof:placetype":"county",

--- a/data/856/322/85/85632285.geojson
+++ b/data/856/322/85/85632285.geojson
@@ -1111,6 +1111,7 @@
         "hasc:id":"BI",
         "icao:code":"9Y",
         "ioc:id":"BDI",
+        "iso:code":"BI",
         "itu:id":"BDI",
         "m49:code":"108",
         "marc:id":"bd",
@@ -1124,6 +1125,7 @@
         "wk:page":"Burundi",
         "wmo:id":"BI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:country_alpha3":"BDI",
     "wof:geom_alt":[
@@ -1147,7 +1149,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1694639530,
+    "wof:lastmodified":1695881187,
     "wof:name":"Burundi",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/687/25/85668725.geojson
+++ b/data/856/687/25/85668725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.124712,
-    "geom:area_square_m":1539754476.488998,
+    "geom:area_square_m":1539754465.601202,
     "geom:bbox":"30.363733,-3.396795,30.850906,-2.892831",
     "geom:latitude":-3.151907,
     "geom:longitude":30.638142,
@@ -302,17 +302,19 @@
         "gn:id":427700,
         "gp:id":2344904,
         "hasc:id":"BI.CA",
+        "iso:code":"BI-CA",
         "iso:id":"BI-CA",
         "qs_pg:id":318327,
         "unlc:id":"BI-CA",
         "wd:id":"Q645033",
         "wk:page":"Cankuzo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"709edd8055f638b918a923c509ea29d7",
+    "wof:geomhash":"eb4c7857052b3c6391a9ecb7d3d827aa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857391,
+    "wof:lastmodified":1695884874,
     "wof:name":"Cankuzo",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/27/85668727.geojson
+++ b/data/856/687/27/85668727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113334,
-    "geom:area_square_m":1399300465.722183,
+    "geom:area_square_m":1399300447.447105,
     "geom:bbox":"29.896781,-3.393871,30.349889,-2.904144",
     "geom:latitude":-3.135593,
     "geom:longitude":30.118855,
@@ -313,17 +313,19 @@
         "gn:id":428218,
         "gp:id":2344907,
         "hasc:id":"BI.KR",
+        "iso:code":"BI-KR",
         "iso:id":"BI-KR",
         "qs_pg:id":1024615,
         "unlc:id":"BI-KR",
         "wd:id":"Q735463",
         "wk:page":"Karuzi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"639591ca601338de2caf402803bf43f4",
+    "wof:geomhash":"5fd7670b90b5d62c7450b6d0ed83cce0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -340,7 +342,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857387,
+    "wof:lastmodified":1695884873,
     "wof:name":"Karuzi",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/31/85668731.geojson
+++ b/data/856/687/31/85668731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150467,
-    "geom:area_square_m":1856301949.031042,
+    "geom:area_square_m":1856301951.243611,
     "geom:bbox":"29.813434,-4.097801,30.411067,-3.632638",
     "geom:latitude":-3.875027,
     "geom:longitude":30.094935,
@@ -310,17 +310,19 @@
         "gn:id":434147,
         "gp:id":2344913,
         "hasc:id":"BI.RT",
+        "iso:code":"BI-RT",
         "iso:id":"BI-RT",
         "qs_pg:id":263283,
         "unlc:id":"BI-RT",
         "wd:id":"Q822566",
         "wk:page":"Rutana Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d1dfee2413478f4d6b11f56c0b76e1c",
+    "wof:geomhash":"64d23ce8910bb94d60b009c83ebe4928",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857389,
+    "wof:lastmodified":1695884874,
     "wof:name":"Rutana",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/35/85668735.geojson
+++ b/data/856/687/35/85668735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173779,
-    "geom:area_square_m":2144877438.428162,
+    "geom:area_square_m":2144877438.422749,
     "geom:bbox":"30.041065,-3.727752,30.678121,-3.206507",
     "geom:latitude":-3.467331,
     "geom:longitude":30.326766,
@@ -302,17 +302,19 @@
         "gn:id":426699,
         "gp:id":2344914,
         "hasc:id":"BI.RY",
+        "iso:code":"BI-RY",
         "iso:id":"BI-RY",
         "qs_pg:id":318339,
         "unlc:id":"BI-RY",
         "wd:id":"Q822578",
         "wk:page":"Ruyigi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4e79039f50323f923177647a3cdc7d7f",
+    "wof:geomhash":"5075113b1ec5f95103bdfb70665763ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857387,
+    "wof:lastmodified":1695884873,
     "wof:name":"Ruyigi",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/39/85668739.geojson
+++ b/data/856/687/39/85668739.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075085,
-    "geom:area_square_m":927049917.646009,
+    "geom:area_square_m":927049919.267435,
     "geom:bbox":"29.222623,-3.31922,29.536525,-2.935853",
     "geom:latitude":-3.134845,
     "geom:longitude":29.383389,
@@ -302,17 +302,19 @@
         "gn:id":428514,
         "gp:id":2344902,
         "hasc:id":"BI.BB",
+        "iso:code":"BI-BB",
         "iso:id":"BI-BB",
         "qs_pg:id":318317,
         "unlc:id":"BI-BB",
         "wd:id":"Q460538",
         "wk:page":"Bubanza Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e6e93c2eae82928de75ba906ac9994b6",
+    "wof:geomhash":"417821c2caa77d06aa8c804654f1d464",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857390,
+    "wof:lastmodified":1695884874,
     "wof:name":"Bubanza",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/45/85668745.geojson
+++ b/data/856/687/45/85668745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130156,
-    "geom:area_square_m":1605735876.440211,
+    "geom:area_square_m":1605735876.439902,
     "geom:bbox":"29.488738,-4.161577,29.916166,-3.557982",
     "geom:latitude":-3.867436,
     "geom:longitude":29.679457,
@@ -310,17 +310,19 @@
         "gn:id":423327,
         "gp:id":2344903,
         "hasc:id":"BI.BI",
+        "iso:code":"BI-BR",
         "iso:id":"BI-BR",
         "qs_pg:id":1134951,
         "unlc:id":"BI-BR",
         "wd:id":"Q431385",
         "wk:page":"Bururi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"33c7a800de647d6fe83a04ec34ea811f",
+    "wof:geomhash":"a43b154bf35e4ae4f7042d3562914c83",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857388,
+    "wof:lastmodified":1695884874,
     "wof:name":"Bururi",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/49/85668749.geojson
+++ b/data/856/687/49/85668749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109464,
-    "geom:area_square_m":1351891289.226154,
+    "geom:area_square_m":1351891289.163272,
     "geom:bbox":"29.000345,-3.10391,29.477227,-2.590879",
     "geom:latitude":-2.827274,
     "geom:longitude":29.209801,
@@ -301,17 +301,19 @@
         "gn:id":430020,
         "gp:id":2344905,
         "hasc:id":"BI.CI",
+        "iso:code":"BI-CI",
         "iso:id":"BI-CI",
         "qs_pg:id":1134958,
         "unlc:id":"BI-CI",
         "wd:id":"Q505596",
         "wk:page":"Cibitoke Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cbe49ef14b05471bad5f7bba12f98d0c",
+    "wof:geomhash":"18d9ca25f6301f2b9474a878dda6c225",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -328,7 +330,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857391,
+    "wof:lastmodified":1695884874,
     "wof:name":"Cibitoke",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/53/85668753.geojson
+++ b/data/856/687/53/85668753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154477,
-    "geom:area_square_m":1906583242.443003,
+    "geom:area_square_m":1906583242.442977,
     "geom:bbox":"29.717616,-3.845078,30.104959,-3.05869",
     "geom:latitude":-3.492271,
     "geom:longitude":29.922229,
@@ -319,17 +319,19 @@
         "gn:id":426271,
         "gp:id":2344906,
         "hasc:id":"BI.GI",
+        "iso:code":"BI-GI",
         "iso:id":"BI-GI",
         "qs_pg:id":80323,
         "unlc:id":"BI-GI",
         "wd:id":"Q720843",
         "wk:page":"Gitega Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f419029fb4466a05c71d904167b69262",
+    "wof:geomhash":"f10d701cb03e8cddbc3966757ede4579",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -346,7 +348,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857389,
+    "wof:lastmodified":1695884874,
     "wof:name":"Gitega",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/57/85668757.geojson
+++ b/data/856/687/57/85668757.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096113,
-    "geom:area_square_m":1186815148.331651,
+    "geom:area_square_m":1186815147.930345,
     "geom:bbox":"29.430283,-3.22926,29.879236,-2.786472",
     "geom:latitude":-3.007043,
     "geom:longitude":29.658924,
@@ -302,17 +302,19 @@
         "gn:id":430951,
         "gp:id":2344908,
         "hasc:id":"BI.KY",
+        "iso:code":"BI-KY",
         "iso:id":"BI-KY",
         "qs_pg:id":1168623,
         "unlc:id":"BI-KY",
         "wd:id":"Q720848",
         "wk:page":"Kayanza Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f7e5d204f22e1dabcd70dd80ad558525",
+    "wof:geomhash":"cb18263aceb591b59a712629138b3351",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857387,
+    "wof:lastmodified":1695884873,
     "wof:name":"Kayanza",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/63/85668763.geojson
+++ b/data/856/687/63/85668763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.153804,
-    "geom:area_square_m":1896656684.050289,
+    "geom:area_square_m":1896656681.837437,
     "geom:bbox":"29.536874,-4.470001,30.191719,-4.002884",
     "geom:latitude":-4.218867,
     "geom:longitude":29.820296,
@@ -308,17 +308,19 @@
         "gn:id":422233,
         "gp:id":2344910,
         "hasc:id":"BI.MA",
+        "iso:code":"BI-MA",
         "iso:id":"BI-MA",
         "qs_pg:id":318328,
         "unlc:id":"BI-MA",
         "wd:id":"Q823740",
         "wk:page":"Makamba Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b769d420aa2bf2f60e3269dd18281893",
+    "wof:geomhash":"eca8151f08f21f0644b06bf498143b75",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -335,7 +337,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857390,
+    "wof:lastmodified":1695884874,
     "wof:name":"Makamba",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/81/85668781.geojson
+++ b/data/856/687/81/85668781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.114714,
-    "geom:area_square_m":1416669520.944957,
+    "geom:area_square_m":1416669520.945037,
     "geom:bbox":"29.635974,-3.0876,30.193385,-2.655063",
     "geom:latitude":-2.874635,
     "geom:longitude":29.924587,
@@ -308,17 +308,19 @@
         "gn:id":430567,
         "gp:id":2344912,
         "hasc:id":"BI.NG",
+        "iso:code":"BI-NG",
         "iso:id":"BI-NG",
         "qs_pg:id":318340,
         "unlc:id":"BI-NG",
         "wd:id":"Q720852",
         "wk:page":"Ngozi Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d6d42e9dd22f2c0667b321d590be658f",
+    "wof:geomhash":"3bbfaeb80a3c6b27287196c608ff0056",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -335,7 +337,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857388,
+    "wof:lastmodified":1695884874,
     "wof:name":"Ngozi",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/83/85668783.geojson
+++ b/data/856/687/83/85668783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137548,
-    "geom:area_square_m":1699122339.510585,
+    "geom:area_square_m":1699122339.510602,
     "geom:bbox":"29.920284,-2.784194,30.41793,-2.327129",
     "geom:latitude":-2.550407,
     "geom:longitude":30.149527,
@@ -310,17 +310,19 @@
         "gn:id":432455,
         "gp:id":2344909,
         "hasc:id":"BI.KI",
+        "iso:code":"BI-KI",
         "iso:id":"BI-KI",
         "qs_pg:id":263282,
         "unlc:id":"BI-KI",
         "wd:id":"Q600840",
         "wk:page":"Kirundo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3e3b2d0effa7438d903facc0082118cf",
+    "wof:geomhash":"d58efef5475ff2b6c8d0bab30629baab",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857391,
+    "wof:lastmodified":1695884875,
     "wof:name":"Kirundo",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/87/85668787.geojson
+++ b/data/856/687/87/85668787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137542,
-    "geom:area_square_m":1698746393.045354,
+    "geom:area_square_m":1698746393.045429,
     "geom:bbox":"30.077131,-3.154604,30.543543,-2.30907",
     "geom:latitude":-2.76314,
     "geom:longitude":30.343246,
@@ -302,17 +302,19 @@
         "gn:id":431747,
         "gp:id":2344911,
         "hasc:id":"BI.MY",
+        "iso:code":"BI-MY",
         "iso:id":"BI-MY",
         "qs_pg:id":191314,
         "unlc:id":"BI-MY",
         "wd:id":"Q822571",
         "wk:page":"Muyinga Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f16033885f578ce6c4bb807e3c0e8b97",
+    "wof:geomhash":"82748d7efd9c514bc68525b9b9e0a313",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857388,
+    "wof:lastmodified":1695884874,
     "wof:name":"Muyinga",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/91/85668791.geojson
+++ b/data/856/687/91/85668791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009896,
-    "geom:area_square_m":122149091.02558,
+    "geom:area_square_m":122149129.48424,
     "geom:bbox":"29.306256,-3.485524,29.425915,-3.30321",
     "geom:latitude":-3.375117,
     "geom:longitude":29.364127,
@@ -311,17 +311,19 @@
         "gn:id":7303939,
         "gp:id":2344900,
         "hasc:id":"BI.BM",
+        "iso:code":"BI-BM",
         "iso:id":"BI-BM",
         "qs_pg:id":219519,
         "unlc:id":"BI-BM",
         "wd:id":"Q1816580",
         "wk:page":"Bujumbura Mairie Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a8e88f470c969492321f25a05ae240e",
+    "wof:geomhash":"1d26c270c53aee86edfd85b10df47847",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -338,7 +340,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857389,
+    "wof:lastmodified":1695884874,
     "wof:name":"Bujumbura Mairie",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/97/85668797.geojson
+++ b/data/856/687/97/85668797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054206,
-    "geom:area_square_m":669175116.081406,
+    "geom:area_square_m":669175116.081414,
     "geom:bbox":"29.502488,-3.426223,29.851808,-3.10749",
     "geom:latitude":-3.271247,
     "geom:longitude":29.651857,
@@ -301,16 +301,18 @@
         "gn:id":425550,
         "gp:id":2344901,
         "hasc:id":"BI.MV",
+        "iso:code":"BI-MU",
         "iso:id":"BI-MU",
         "qs_pg:id":1097031,
         "wd:id":"Q671086",
         "wk:page":"Muramvya Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bbb2d88c87983efd49caa880d868d785",
+    "wof:geomhash":"b036496096336f7de67c5cb59937987b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -327,7 +329,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857390,
+    "wof:lastmodified":1695884874,
     "wof:name":"Muramvya",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/687/99/85668799.geojson
+++ b/data/856/687/99/85668799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071867,
-    "geom:area_square_m":887057799.894321,
+    "geom:area_square_m":887057772.823159,
     "geom:bbox":"29.211046,-3.676085,29.598558,-3.249048",
     "geom:latitude":-3.434082,
     "geom:longitude":29.448243,
@@ -313,17 +313,19 @@
         "gn:id":7303940,
         "gp:id":56017453,
         "hasc:id":"BI.BL",
+        "iso:code":"BI-BL",
         "iso:id":"BI-BL",
         "qs_pg:id":1105156,
         "unlc:id":"BI-BL",
         "wd:id":"Q645043",
         "wk:page":"Bujumbura Rural Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4c4ca56ae08cbafbaa709c1c1905aa79",
+    "wof:geomhash":"15d7bd26f44007b0a09184cec0fdf72f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -340,7 +342,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857390,
+    "wof:lastmodified":1695884874,
     "wof:name":"Bujumbura Rural",
     "wof:parent_id":85632285,
     "wof:placetype":"region",

--- a/data/856/688/01/85668801.geojson
+++ b/data/856/688/01/85668801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066804,
-    "geom:area_square_m":824505642.04491,
+    "geom:area_square_m":824505642.045026,
     "geom:bbox":"29.566116,-3.720205,29.875007,-3.297831",
     "geom:latitude":-3.490551,
     "geom:longitude":29.715299,
@@ -281,15 +281,17 @@
         "gn:id":434386,
         "gp:id":-2344901,
         "hasc:id":"BI.MW",
+        "iso:code":"BI-MW",
         "iso:id":"BI-MW",
         "unlc:id":"BI-MW",
         "wd:id":"Q2458075"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BI",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"34eef2578c1dec5f3ec8fbcf30ef885e",
+    "wof:geomhash":"3331165952c9fe7920b3f3020b312e21",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
         "run",
         "fra"
     ],
-    "wof:lastmodified":1690857386,
+    "wof:lastmodified":1695884874,
     "wof:name":"Mwaro",
     "wof:parent_id":85632285,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.